### PR TITLE
feat(cd): Automate build and deployment of bentobox-sdk docs on Github Pages

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,50 @@
+#
+# bento-box
+# continuous deployment (cd) pipeline
+#
+
+name: "CI Pipeline"
+on:
+  push:
+    branches:
+      - master
+      # TODO(mrzzy): remove 
+      - ci/docgen-sdk
+
+  # builds & publishes docs for the sdk component to Github 
+  publish-docs-sdk:
+    need: build-test-sdk
+    runs-on: ubuntu-20.04
+    name: "Publish bentobox-sdk Docs to Github Pages"
+    env:
+      SDK_DOC_DIR: docs
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # fetch all history for all branches and tags
+          fetch-depth: 0 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: "Pull dependencies"
+        run: |
+          make dep-sdk-dev
+      - name: "Build bentobox-sdk Docs"
+        run: |
+          make build-sdk-docs
+      - name: "Publish bentobox-sdk Docs to Github Pages"
+        run: |
+          git checkout gh-pages
+          git add ${SDK_DOC_DIR}
+          # check for staged changes to SDK docs
+          if git diff --staged --quiet
+          then
+            echo "No SDK Docs changes to commit."
+            exit 0
+          fi
+
+          # Commit changes as Github Actions bot
+          git config user.name 'github-actions'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -a -m "CI: Update docs built from master sha: ${GITHUB_REF}"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,7 +34,7 @@ jobs:
           make build-sdk
       - name: "Build bentobox-sdk Docs"
         run: |
-          make build-sdk-docs
+          make build-sdk-docs SDK_DOC_DIR=${SDK_DOC_DIR}
       - name: "Publish bentobox-sdk Docs to Github Pages"
         run: |
           git checkout gh-pages

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,17 +3,16 @@
 # continuous deployment (cd) pipeline
 #
 
-name: "CI Pipeline"
+name: "CD Pipeline"
 on:
   push:
     branches:
       - master
       # TODO(mrzzy): remove 
       - ci/docgen-sdk
-
+jobs:
   # builds & publishes docs for the sdk component to Github 
   publish-docs-sdk:
-    need: build-test-sdk
     runs-on: ubuntu-20.04
     name: "Publish bentobox-sdk Docs to Github Pages"
     env:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,7 +34,10 @@ jobs:
           make build-sdk
       - name: "Build bentobox-sdk Docs"
         run: |
-          make build-sdk-docs SDK_DOC_DIR=${SDK_DOC_DIR}
+          make clean-sdk-docs build-sdk-docs SDK_DOC_DIR=${SDK_DOC_DIR}
+          # move generated docs from docs/bento to top level docs/
+          mv ${SDK_DOC_DIR}/bento /tmp/bento
+          mv -f /tmp/bento ${SDK_DOC_DIR}
       - name: "Publish bentobox-sdk Docs to Github Pages"
         run: |
           git checkout gh-pages
@@ -52,4 +55,4 @@ jobs:
           git commit -a -m "CI: Update docs built from master commit: ${GITHUB_SHA}"
           
           # Publish changes by pushing to Github
-          git push 
+          git push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -49,4 +49,7 @@ jobs:
           # Commit changes as Github Actions bot
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -a -m "CI: Update docs built from master sha: ${GITHUB_REF}"
+          git commit -a -m "CI: Update docs built from master commit: ${GITHUB_SHA}"
+          
+          # Publish changes by pushing to Github
+          git push 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: "Publish bentobox-sdk Docs to Github Pages"
     env:
-      SDK_DOC_DIR: docs
+      SDK_DOC_DIR: /tmp/docs
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
       - uses: actions/checkout@v2
@@ -34,14 +34,15 @@ jobs:
           make build-sdk
       - name: "Build bentobox-sdk Docs"
         run: |
-          git checkout gh-pages
-          make clean-sdk-docs build-sdk-docs SDK_DOC_DIR=${SDK_DOC_DIR}
-          # move generated docs from docs/bento to top level docs/
-          mv ${SDK_DOC_DIR}/bento /tmp/bento
-          mv -f /tmp/bento ${SDK_DOC_DIR}
+          make build-sdk-docs SDK_DOC_DIR=${SDK_DOC_DIR}
       - name: "Publish bentobox-sdk Docs to Github Pages"
         run: |
-          git add ${SDK_DOC_DIR}
+          git checkout gh-pages
+          # move generated docs to top level docs/ and stage changes
+          rm -rf docs
+          mv -f ${SDK_DOC_DIR}/bento docs
+          git add docs
+
           # check for staged changes to SDK docs
           if git diff --staged --quiet
           then

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,13 +34,13 @@ jobs:
           make build-sdk
       - name: "Build bentobox-sdk Docs"
         run: |
+          git checkout gh-pages
           make clean-sdk-docs build-sdk-docs SDK_DOC_DIR=${SDK_DOC_DIR}
           # move generated docs from docs/bento to top level docs/
           mv ${SDK_DOC_DIR}/bento /tmp/bento
           mv -f /tmp/bento ${SDK_DOC_DIR}
       - name: "Publish bentobox-sdk Docs to Github Pages"
         run: |
-          git checkout gh-pages
           git add ${SDK_DOC_DIR}
           # check for staged changes to SDK docs
           if git diff --staged --quiet

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -53,7 +53,8 @@ jobs:
           # Commit changes as Github Actions bot
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git commit -a -m "CI: Update docs built from master commit: ${GITHUB_SHA}"
+          GIT_REF_NAME="$(echo ${GITHUB_REF} | sed -e "s|\w*/\w*/||")"
+          git commit -a -m "CI: Update docs built from ${GIT_REF_NAME} commit: ${GITHUB_SHA}"
           
           # Publish changes by pushing to Github
           git push

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - master
-      # TODO(mrzzy): remove 
-      - ci/docgen-sdk
 jobs:
   # builds & publishes docs for the sdk component to Github 
   publish-docs-sdk:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev
+      - name: "Build bentobox-sdk"
+        run: |
+          make build-sdk
       - name: "Build bentobox-sdk Docs"
         run: |
           make build-sdk-docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,3 +84,20 @@ jobs:
       - name: "Unit Test bentobox-sdk"
         run: |
           make test-sdk
+
+  # builds docs for the sdk component
+  build-docs-sdk:
+    need: build-test-sdk
+    runs-on: ubuntu-20.04
+    name: "Build & Push bentobox-sdk Docs"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: "Pull dependencies"
+        run: |
+          make dep-sdk-dev
+      - name: "Build bentobox-sdk Docs"
+        run: |
+          env make build-sdk-docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
 
   # builds docs for the sdk component
   build-docs-sdk:
-    need: build-test-sdk
+    needs: build-test-sdk
     runs-on: ubuntu-20.04
     name: "Build & Push bentobox-sdk Docs"
     steps:
@@ -100,4 +100,4 @@ jobs:
           make dep-sdk-dev
       - name: "Build bentobox-sdk Docs"
         run: |
-          env make build-sdk-docs
+          make build-sdk-docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,9 @@ jobs:
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev
+      - name: "Build bentobox-sdk"
+        run: |
+          make build-sdk
       - name: "Build bentobox-sdk Docs"
         run: |
           make build-sdk-docs

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ PROTOC:=protoc
 MKDIR:=mkdir -p
 MV:=mv -f
 
-.PHONY: deps build test clean run
+.PHONY: kjeps build test clean run
 
 build: build-sim
 
@@ -63,18 +63,13 @@ BLACK_FMT:=python -m black
 PYTEST:=python -m pytest
 PDOC:=python -m pdoc
 
-.PHONY: format-sdk clean-sdk build-sdk build-sdk-docs  dep-sdk-dev test-sdk lint-sdk
+.PHONY: format-sdk clean-sdk build-sdk dep-sdk-dev test-sdk lint-sdk
 
 dep-sdk-dev:
 	pip install -r $(SDK_SRC)/requirements-dev.txt
 
 build-sdk: dep-sdk-dev lint-sdk
 	cd $(SDK_SRC) && $(PYTHON) setup.py sdist bdist_wheel
-
-build-sdk-docs: $(SDK_SRC)/docs
-
-$(SDK_SRC)/docs: dep-sdk-dev
-	cd $(SDK_SRC) && $(PDOC) --html -o $(notdir $@) bento
 
 format-sdk: dep-sdk-dev
 	$(BLACK_FMT) $(SDK_SRC)/bento
@@ -89,6 +84,17 @@ test-sdk: dep-sdk-dev
 
 clean-sdk:
 	cd $(SDK_SRC) && $(PYTHON) setup.py clean --all
+
+# Bento - SDK docs
+.PHONY: build-sdk-docs clean-sdk-docs
+
+build-sdk-docs: $(SDK_SRC)/docs
+
+$(SDK_SRC)/docs: dep-sdk-dev
+	cd $(SDK_SRC) && $(PDOC) --html -o $(notdir $@) bento
+
+clean-sdk-docs: $(SDK_SRC)/docs
+	$(RM) $(notdir $@)
 
 # spellcheck bentobox codebase
 .PHONY: spellcheck

--- a/makefile
+++ b/makefile
@@ -94,8 +94,8 @@ build-sdk-docs: $(SDK_DOC_DIR)
 $(SDK_DOC_DIR): dep-sdk-dev
 	$(PDOC) --html -o $(SDK_DOC_DIR) $(SDK_SRC)/bento
 
-clean-sdk-docs: $(SDK_SRC)/docs
-	$(RM) $(notdir $@)
+clean-sdk-docs: $(SDK_DOC_DIR)
+	$(RM) $<
 
 # spellcheck bentobox codebase
 .PHONY: spellcheck autocorrect

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ PROTOC:=protoc
 MKDIR:=mkdir -p
 MV:=mv -f
 
-.PHONY: kjeps build test clean run
+.PHONY: deps build test clean run
 
 build: build-sim
 
@@ -86,18 +86,19 @@ clean-sdk:
 	cd $(SDK_SRC) && $(PYTHON) setup.py clean --all
 
 # Bento - SDK docs
+SDK_DOC_DIR:=$(SDK_SRC)/docs
 .PHONY: build-sdk-docs clean-sdk-docs
 
-build-sdk-docs: $(SDK_SRC)/docs
+build-sdk-docs: $(SDK_DOC_DIR)
 
-$(SDK_SRC)/docs: dep-sdk-dev
-	cd $(SDK_SRC) && $(PDOC) --html -o $(notdir $@) bento
+$(SDK_DOC_DIR): dep-sdk-dev
+	$(PDOC) --html -o $(SDK_DOC_DIR) $(SDK_SRC)/bento
 
 clean-sdk-docs: $(SDK_SRC)/docs
 	$(RM) $(notdir $@)
 
 # spellcheck bentobox codebase
-.PHONY: spellcheck
+.PHONY: spellcheck autocorrect
 
 spellcheck:
 	codespell -s


### PR DESCRIPTION
Add CI Job to check that bentobox-sdk docs can be generated with [pdoc3](https://github.com/pdoc3/pdoc/)
- Extracts docs from docstrings in SDK codebase.

Adds new Continuous Deployment pipeline that runs only on `master`:
- Automates build deployment of bentobox-sdk docs on Github Pages via CD jobs by pushing to `gh-pages` branch.

> Example of how the CD job looks like [here](https://github.com/joeltio/bento-box/runs/1636591809).


