### PR TITLE
feat(ci): Add caching of docker layers to speed up CI build of bentobox-sim container.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,12 +75,13 @@ jobs:
 
       # Cache pip dependencies to speed up job
       - name: "Find pip Cache Directory"
+        id: pip-cache-dir
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
       - name: "Retrieve Cached dependencies"
         uses: actions/cache@v2
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: pip-${{ matrix.python }}-${{ matrix.os }}-${{ hashFiles('sdk/requirements*.txt') }}
           restore-keys: |
             pip-${{ matrix.python }}-${{ matrix.os }}-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,22 +81,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
-
-      # cache pip dependencies to speed up job
-      - name: "Find pip Cache Directory"
-        id: pip-cache-dir
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: "Retrieve Cached dependencies"
-        uses: actions/cache@v2
-        # ignore the failure of noncritical cache step
-        continue-on-error: true
-        with:
-          path: ${{ steps.pip-cache-dir.outputs.dir }}
-          key: pip-${{ matrix.python }}-${{ matrix.os }}-${{ hashFiles('sdk/requirements*.txt') }}
-          restore-keys: |
-            pip-${{ matrix.python }}-${{ matrix.os }}-
-
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,16 @@ jobs:
     name: "Build & Test bentobox-sim"
     steps:
       - uses: actions/checkout@v2
+
+      # cache docker layers to speed up docker build
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        # Ignore the failure of noncritical cache step
+        continue-on-error: true
+        with:
+          key: docker-${ hashFiles('infra/docker/sim/Dockerfile', '**/CMakeLists.txt') }
+          restore-keys: |
+            docker-
+
       - name: "Build bentobox-sim"
         run: |
           docker build -t bentobox-sim -f infra/docker/sim/Dockerfile .
@@ -73,13 +83,15 @@ jobs:
         with:
           python-version: ${{matrix.python}}
 
-      # Cache pip dependencies to speed up job
+      # cache pip dependencies to speed up job
       - name: "Find pip Cache Directory"
         id: pip-cache-dir
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
       - name: "Retrieve Cached dependencies"
         uses: actions/cache@v2
+        # ignore the failure of noncritical cache step
+        continue-on-error: true
         with:
           path: ${{ steps.pip-cache-dir.outputs.dir }}
           key: pip-${{ matrix.python }}-${{ matrix.os }}-${{ hashFiles('sdk/requirements*.txt') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,8 @@ jobs:
         # Ignore the failure of noncritical cache step
         continue-on-error: true
         with:
-          key: docker-${ hashFiles('infra/docker/sim/Dockerfile', '**/CMakeLists.txt') }
+          # {hash} replace with hash of the built sim container
+          key: docker-{hash}
           restore-keys: |
             docker-
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,6 @@
 
 name: "CI Pipeline"
 on: push
-env:
-  DOCKER_BUILDKIT: 1
 jobs:
   # quick check that protos can be compiled by protoc
   check-protos:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,19 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
+
+      # Cache pip dependencies to speed up job
+      - name: "Find pip Cache Directory"
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: "Retrieve Cached dependencies"
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ matrix.python }}-${{ matrix.os }}-${{ hashFiles('sdk/requirements*.txt') }}
+          restore-keys: |
+            pip-${{ matrix.python }}-${{ matrix.os }}-
+
       - name: "Pull dependencies"
         run: |
           make dep-sdk-dev

--- a/infra/docker/sim/Dockerfile
+++ b/infra/docker/sim/Dockerfile
@@ -24,5 +24,5 @@ COPY protos /repo/protos
 COPY sim /repo/sim
 RUN make clean-sim build-sim
 
-# run simlulator
+# run simulator
 CMD make run-sim


### PR DESCRIPTION
Add caching of docker layers to speed up CI build of bentobox-sim container.
- Docker layer caching provided via [this Github Action](https://github.com/satackey/action-docker-layer-caching).
- Removed use of Docker Buildkit as caching did not work with the buildkit container builder.
- Reduces the build time of the  bentobox-sim container from around 10 minutes to around 6-7 minutes (no changes: 4 mins)

> Attempted to add caching to pip dependencies on the SDK side as well, but that did not significantly improve build performance.