### PR TITLE
ci: Fix bentobox-sim build not properly taking advantage of Docker Layer caching

### DIFF
--- a/infra/docker/sim/Dockerfile
+++ b/infra/docker/sim/Dockerfile
@@ -1,7 +1,7 @@
 #
 # bento-box
 # sim component container
-# 
+#
 
 FROM ubuntu:20.04 AS build
 
@@ -19,15 +19,18 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
 
 # pull build dependencies
 COPY makefile /repo/makefile
-RUN mkdir -p sim/lib/core sim/build
-COPY sim/CMakeLists.txt sim/
-COPY sim/lib/core/CMakeLists.txt sim/lib/core/
+COPY sim/dependencies.cmake /repo/sim/CMakeLists.txt
+RUN mkdir -p sim/build
 RUN make dep-sim
 
 # build simulator
 COPY protos /repo/protos
-COPY sim /repo/sim
-RUN make clean-sim build-sim
+COPY sim/CMakeLists.txt /repo/sim/CMakeLists.txt
+COPY sim/dependencies.cmake /repo/sim/dependencies.cmake
+COPY sim/lib /repo/sim/lib
+COPY sim/src /repo/sim/src
+COPY sim/include /repo/sim/include
+RUN make build-sim
 
 # run simulator
 CMD make run-sim

--- a/infra/docker/sim/Dockerfile
+++ b/infra/docker/sim/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /repo
 WORKDIR /repo
 # install apt package dependencies
 RUN apt-get update && apt-get install -y  --no-install-recommends \
-    build-essential g++-10 cmake git \
+    build-essential g++-10 cmake git python3-dev \
     libglfw3-dev xvfb xorg-dev \
     ca-certificates \
     # use g++ 10 as compiler

--- a/infra/docker/sim/Dockerfile
+++ b/infra/docker/sim/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir /repo
 WORKDIR /repo
 # install apt package dependencies
 RUN apt-get update && apt-get install -y  --no-install-recommends \
-    build-essential g++-10 cmake git python3-dev \
+    build-essential g++-10 cmake git \
     libglfw3-dev xvfb xorg-dev \
     ca-certificates \
     # use g++ 10 as compiler

--- a/infra/docker/sim/Dockerfile
+++ b/infra/docker/sim/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # setup project dir
 RUN mkdir /repo
 WORKDIR /repo
-# install build dependencies
+# install apt package dependencies
 RUN apt-get update && apt-get install -y  --no-install-recommends \
     build-essential g++-10 cmake git \
     libglfw3-dev xvfb xorg-dev \
@@ -17,9 +17,14 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
     # use g++ 10 as compiler
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
 
+# pull build dependencies
+COPY makefile /repo/makefile
+RUN mkdir -p sim/lib/core sim/build
+COPY sim/CMakeLists.txt sim/
+COPY sim/lib/core/CMakeLists.txt sim/lib/core/
+RUN make dep-sim
 
 # build simulator
-COPY makefile /repo/makefile
 COPY protos /repo/protos
 COPY sim /repo/sim
 RUN make clean-sim build-sim

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ clean: clean-sim
 ARCH:=$(shell uname -m)
 OS:=$(if $(filter Darwin,$(shell uname -s)),osx,linux)
 BIN_DIR:=/usr/local/bin
-deps: dep-protoc dev-sdk-dev
+deps: dep-protoc dep-sim dev-sdk-dev
 
 PROTOC_VERSION:=3.13.0
 
@@ -40,10 +40,13 @@ SIM_TEST:=bentobox-test
 SIM_SRC:=sim
 SIM_BUILD_DIR:=sim/build
 
-.PHONY: build-sim test-sim clean-sim
+.PHONY: build-sim test-sim clean-sim dep-sim
 
-build-sim:
+dep-sim:
 	$(CMAKE) -S $(SIM_SRC) -B $(SIM_BUILD_DIR) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+	$(CMAKE) --build $(SIM_BUILD_DIR) --parallel $(shell nproc --all) --target deps
+
+build-sim: dep-sim
 	$(CMAKE) --build $(SIM_BUILD_DIR) --parallel $(shell nproc --all) \
 		--target $(SIM_TARGET) --target $(SIM_TEST)
 

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -111,3 +111,10 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(googletest)
 target_link_libraries(${TARGET_TEST} PRIVATE -Wl,--no-whole-archive gtest_main)
+
+# phony/target that does pulls in dependencies but does not build anything
+set(TARGET_DEPS "deps")
+add_custom_target(
+    ${TARGET_DEPS}
+    DEPENDS libprotobuf grpc++ grpc++_reflection gtest_main
+)

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -1,7 +1,4 @@
 cmake_minimum_required(VERSION 3.16)
-include(FetchContent)
-# show progress for when fetching FetchContent dependencies
-set(FETCHCONTENT_QUIET OFF)
 # use cmake policy to make option() to honor normal variables
 # http://shadow.nd.rl.ac.uk/ICP_Binaries/CMake/doc/cmake/html/policy/CMP0077.html
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
@@ -42,30 +39,10 @@ target_link_libraries(${TARGET_TEST}
 )
 
 ## Library Dependencies
-# target library dependencies to c++ 17
-set(CMAKE_CXX_STANDARD 17)
+# fetch dependencies
+include("dependencies.cmake")
 
 # GRPC/Protobuf
-FetchContent_Declare(
-    grpc
-    GIT_REPOSITORY https://github.com/grpc/grpc.git
-    GIT_TAG        v1.33.2
-    GIT_PROGRESS   TRUE
-)
-# disable redundant dependencies targets
-# disable unused protobuf targets
-set(protobuf_BUILD_TESTS OFF)
-# disable unused grpc plugin targets
-set(gRPC_BUILD_CSHARP_EXT OFF)
-set(gRPC_BUILD_GRPC_CSHARP_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_NODE_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_PHP_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_PYTHON_PLUGIN OFF)
-set(gRPC_BUILD_GRPC_RUBY_PLUGIN OFF)
-# disable abseil tests targets
-set(BUILD_TESTING OFF)
-FetchContent_MakeAvailable(grpc)
 # link protobuf/grpc libraries
 foreach(target IN ITEMS ${TARGETS})
     target_include_directories(${target} PRIVATE "${PROTOBUF_DIR}/src")
@@ -85,38 +62,22 @@ string(REPLACE ".proto" ".pb.cc" PROTO_BIND_SOURCES "${PROTO_BINDS}")
 string(REPLACE ".proto" ".grpc.pb.cc" PROTO_GRPC_SOURCES "${PROTO_BINDS}")
 string(REPLACE ".proto" ".pb.h" PROTO_BIND_HEADERS "${PROTO_BINDS}")
 # run protoc with grpc_cpp_plugin to generate c++ bindings
-if(EXISTS "${PROTOS_DIR}")
-    add_custom_command(
-        OUTPUT ${PROTO_BIND_HEADERS} ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES}
-        COMMAND $<TARGET_FILE:protoc>
-        ARGS
-            -I ${PROTOS_DIR}
-            --grpc_out ${PROTO_BINDS_DIR}
-            --cpp_out ${PROTO_BINDS_DIR}
-            --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
-            ${PROTO_DEFS}
-        DEPENDS ${PROTO_DEFS} $<TARGET_FILE:protoc> $<TARGET_FILE:grpc_cpp_plugin>
-    )
-    foreach(target IN ITEMS ${TARGETS})
-        target_sources(${target} PRIVATE ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES})
-        target_include_directories(${target} PRIVATE ${PROTO_BINDS_DIR})
-    endforeach()
-endif()
+add_custom_command(
+    OUTPUT ${PROTO_BIND_HEADERS} ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES}
+    COMMAND $<TARGET_FILE:protoc>
+    ARGS
+        -I ${PROTOS_DIR}
+        --grpc_out ${PROTO_BINDS_DIR}
+        --cpp_out ${PROTO_BINDS_DIR}
+        --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
+        ${PROTO_DEFS}
+    DEPENDS ${PROTO_DEFS} $<TARGET_FILE:protoc> $<TARGET_FILE:grpc_cpp_plugin>
+)
+foreach(target IN ITEMS ${TARGETS})
+    target_sources(${target} PRIVATE ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES})
+    target_include_directories(${target} PRIVATE ${PROTO_BINDS_DIR})
+endforeach()
 
 ## Test Dependencies
-# Google test
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
-  GIT_PROGRESS   TRUE
-)
-FetchContent_MakeAvailable(googletest)
+# link googletest
 target_link_libraries(${TARGET_TEST} PRIVATE -Wl,--no-whole-archive gtest_main)
-
-# phony/target that does pulls in dependencies but does not build anything
-set(TARGET_DEPS "deps")
-add_custom_target(
-    ${TARGET_DEPS}
-    DEPENDS libprotobuf grpc++ grpc++_reflection gtest_main
-)

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -85,21 +85,23 @@ string(REPLACE ".proto" ".pb.cc" PROTO_BIND_SOURCES "${PROTO_BINDS}")
 string(REPLACE ".proto" ".grpc.pb.cc" PROTO_GRPC_SOURCES "${PROTO_BINDS}")
 string(REPLACE ".proto" ".pb.h" PROTO_BIND_HEADERS "${PROTO_BINDS}")
 # run protoc with grpc_cpp_plugin to generate c++ bindings
-add_custom_command(
-    OUTPUT ${PROTO_BIND_HEADERS} ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES}
-    COMMAND $<TARGET_FILE:protoc>
-    ARGS
-        -I ${PROTOS_DIR}
-        --grpc_out ${PROTO_BINDS_DIR}
-        --cpp_out ${PROTO_BINDS_DIR}
-        --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
-        ${PROTO_DEFS}
-    DEPENDS ${PROTO_DEFS} $<TARGET_FILE:protoc> $<TARGET_FILE:grpc_cpp_plugin>
-)
-foreach(target IN ITEMS ${TARGETS})
-    target_sources(${target} PRIVATE ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES})
-    target_include_directories(${target} PRIVATE ${PROTO_BINDS_DIR})
-endforeach()
+if(EXISTS "${PROTOS_DIR}")
+    add_custom_command(
+        OUTPUT ${PROTO_BIND_HEADERS} ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES}
+        COMMAND $<TARGET_FILE:protoc>
+        ARGS
+            -I ${PROTOS_DIR}
+            --grpc_out ${PROTO_BINDS_DIR}
+            --cpp_out ${PROTO_BINDS_DIR}
+            --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>
+            ${PROTO_DEFS}
+        DEPENDS ${PROTO_DEFS} $<TARGET_FILE:protoc> $<TARGET_FILE:grpc_cpp_plugin>
+    )
+    foreach(target IN ITEMS ${TARGETS})
+        target_sources(${target} PRIVATE ${PROTO_BIND_SOURCES} ${PROTO_GRPC_SOURCES})
+        target_include_directories(${target} PRIVATE ${PROTO_BINDS_DIR})
+    endforeach()
+endif()
 
 ## Test Dependencies
 # Google test

--- a/sim/dependencies.cmake
+++ b/sim/dependencies.cmake
@@ -1,0 +1,49 @@
+#
+# bentobox-sim
+# Library Dependencies
+#
+
+cmake_minimum_required(VERSION 3.16)
+include(FetchContent)
+
+# show progress for when fetching FetchContent dependencies
+set(FETCHCONTENT_QUIET OFF)
+# target library dependencies to c++ 17
+set(CMAKE_CXX_STANDARD 17)
+
+# GRPC/Protobuf
+# disable unused protobuf targets
+set(protobuf_BUILD_TESTS OFF)
+# disable unused grpc plugin targets
+set(gRPC_BUILD_CSHARP_EXT OFF)
+set(gRPC_BUILD_GRPC_CSHARP_PLUGIN OFF)
+set(gRPC_BUILD_GRPC_NODE_PLUGIN OFF)
+set(gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN OFF)
+set(gRPC_BUILD_GRPC_PHP_PLUGIN OFF)
+set(gRPC_BUILD_GRPC_PYTHON_PLUGIN OFF)
+set(gRPC_BUILD_GRPC_RUBY_PLUGIN OFF)
+# disable abseil tests targets
+set(BUILD_TESTING OFF)
+FetchContent_Declare(
+    grpc
+    GIT_REPOSITORY https://github.com/grpc/grpc.git
+    GIT_TAG        v1.33.2
+    GIT_PROGRESS   TRUE
+)
+FetchContent_MakeAvailable(grpc)
+
+# Google test
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.10.0
+  GIT_PROGRESS   TRUE
+)
+FetchContent_MakeAvailable(googletest)
+
+# phony/target that does pulls & builds in dependencies
+set(TARGET_DEPS "deps")
+add_custom_target(
+    ${TARGET_DEPS}
+    DEPENDS libprotobuf grpc++ grpc++_reflection gtest_main
+)


### PR DESCRIPTION
Fixes: #12

Fixes bentobox-sim build not properly taking advantage of Docker Layer caching by:
- Adds project makefile target  `dep-sim`  that does pulls in build dependencies without building.
- Split out depdendency fetching `sim/CMakeLists.txt`  into `dependencies.cmake`.
-  `dependencies.cmake` is a standalone `CMakeList.txt` that can be used to fetch dependencies only.
- Since the dependencies are pulled in before the source code is copied in the Dockerfile, this should allow them to cached even while Sim's source code changes.