### PR TITLE
feat(sdk): Preprocess AugAssign into separate Assignment and Binary Operation

### DIFF
--- a/sdk/bento/graph/__init__.py
+++ b/sdk/bento/graph/__init__.py
@@ -10,6 +10,7 @@ from inspect import getsource
 from textwrap import dedent
 from typing import Callable, List
 
+from bento.graph.preprocessors import preprocess_augassign
 from bento.graph.analyzers import (
     analyze_func,
     analyze_convert_fn,
@@ -27,6 +28,9 @@ Transform = Callable[[AST], AST]
 
 def compile_graph(
     convert_fn: Callable,
+    preprocessors: List[Transform] = [
+        preprocess_augassign,
+    ],
     analyzers: List[Analyzer] = [
         analyze_func,
         analyze_convert_fn,
@@ -38,10 +42,18 @@ def compile_graph(
 ) -> Graph:
     """Compiles the given `convert_fn` into a computation Graph.
 
-    Compiles by converting the given `convert_fn` function to AST,
+    Compiles by converting the given `convert_fn` function to AST
+    applying the given `preprocessors` transforms to perform preprocessing on the AST,
     applying given `analyzers` on the AST to perform static analysis,
     linting the AST with the given `linters` to perform static checks,
-    applying the given `transforms` to transform the AST.
+    applying the given `transforms` to transform the AST to a function that plots the computational graph.
+
+    Note:
+        Even though both `preprocessors` and `transforms` are comprised of  a list of `Transform`s
+        `preprocessors` transforms are applied before any static analysis is done while
+        `transforms` are applied after static analysis. This allows `preprocessors` to focus
+        on transforming the AST to make static analysis easier while `transforms` to focus on
+        transforming the AST to plot a computation graph.
 
     The transformed AST is converted back to source where it can be imported
     to provide a compiled function that builds the graph using the given `Plotter` on call.
@@ -56,21 +68,26 @@ def compile_graph(
             # ...
 
     Args:
-        convert_fn:
-            Target function containing the source to convert to the computation graph.
+        convert_fn: Target function containing the source to convert to the computation graph.
             The function should take in one parameter: a `Plotter` instance which
             allows users to access graphing specific operations. Must be a plain Python
             Function, not a Callable class, method, classmethod or staticmethod.
-        analyzers:
-            List of `Analyzer`s that are run sequentially on the AST perform static analysis.
-            Analyzers can add attributes to AST nodes but not modify the AST tree.
-        linters:
-            List of `Linter`s that are run sequentially on the AST to perform
+
+        preprocessors: List of `Transform`s that are run sequentially to apply
+            preprocesssing transforms to the AST before any static analysis is done.
+            Typically these AST transforms make static analysis easier by simplifying the AST.
+
+        analyzers: List of `Analyzer`s that are run sequentially on the AST perform
+            static analysis.  Analyzers can add attributes to AST nodes but not
+            modify the AST tree.
+
+        linters: List of `Linter`s that are run sequentially on the AST to perform
             static checks on the convertability of the AST. `Linter`s are expected
             to throw exception when failing a check.
-        transforms:
-            List of `Transform`s that are run sequentially to transform the AST to
-            a compiled function (in AST form) that builds the computation graph when called.
+
+        transforms: List of `Transform`s that are run sequentially to transform the
+            AST to a compiled function (in AST form) that builds the computation
+            graph when called.
 
     Returns:
         The converted computational Graph as a `Graph` protobuf message.
@@ -80,6 +97,10 @@ def compile_graph(
 
     # parse ast from function source
     ast = parse_ast(convert_fn)
+
+    # apply preprocessors to apply preprocesssing transforms on the ASt
+    for preprocessor in preprocessors:
+        ast = preprocessor(ast)
 
     # apply analyzers to conduct static analysis
     for analyzer in analyzers:

--- a/sdk/bento/graph/ast.py
+++ b/sdk/bento/graph/ast.py
@@ -16,6 +16,23 @@ from textwrap import dedent
 from typing import Any, Dict, Optional
 
 
+class FuncASTTransform(gast.NodeTransformer):
+    """Defines a AST transformation with a given transform function"""
+
+    def __init__(self, transform_fn: Callable[[AST], AST]):
+        super().__init__()
+        self.transform_fn = transform_fn
+
+    def visit(self, node: AST) -> AST:
+        # recursively visit child nodes
+        super().visit(node)
+        # on visit: transform node and fix code locations
+        new_node = gast.copy_location(new_node=self.transform_fn(node), old_node=node)
+        new_node = gast.fix_missing_locations(new_node)
+
+        return new_node
+
+
 def parse_ast(obj: Any) -> AST:
     """Parse the AST of the given `obj`.
 

--- a/sdk/bento/graph/ast.py
+++ b/sdk/bento/graph/ast.py
@@ -95,6 +95,8 @@ def load_ast_module(ast: AST) -> Any:
         mod_spec = spec_from_file_location("compiled", f.name)
         module = module_from_spec(mod_spec)
         mod_spec.loader.exec_module(module)
+    # delete the temporary file manually as NamedTemporaryFile runs into
+    # permission issues trying to remove it on Windows.
     os.remove(f.name)
 
     return module

--- a/sdk/bento/graph/ast.py
+++ b/sdk/bento/graph/ast.py
@@ -13,7 +13,7 @@ from importlib.util import spec_from_file_location, module_from_spec
 from gast import AST, Call, FunctionDef, keyword, Name, Load, Attribute
 from inspect import getsource, cleandoc
 from textwrap import dedent
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Callable
 
 
 class FuncASTTransform(gast.NodeTransformer):

--- a/sdk/bento/graph/ast.py
+++ b/sdk/bento/graph/ast.py
@@ -4,7 +4,7 @@
 # AST Utils
 #
 
-
+import os
 import gast
 
 from tempfile import NamedTemporaryFile
@@ -88,12 +88,13 @@ def call_func_ast(
 def load_ast_module(ast: AST) -> Any:
     # TODO(mrzzy) docs
     src = unparse(ast)
-    with NamedTemporaryFile(mode="w", suffix=".py", delete=True) as f:
+    with NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
         f.write(src)
-        f.flush()
+        f.close()
         # import the source as a module
         mod_spec = spec_from_file_location("compiled", f.name)
         module = module_from_spec(mod_spec)
         mod_spec.loader.exec_module(module)
+    os.remove(f.name)
 
     return module

--- a/sdk/bento/graph/ast.py
+++ b/sdk/bento/graph/ast.py
@@ -88,7 +88,7 @@ def call_func_ast(
 def load_ast_module(ast: AST) -> Any:
     # TODO(mrzzy) docs
     src = unparse(ast)
-    with NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+    with NamedTemporaryFile(mode="w", suffix=".py", delete=True) as f:
         f.write(src)
         f.flush()
         # import the source as a module

--- a/sdk/bento/graph/preprocessors.py
+++ b/sdk/bento/graph/preprocessors.py
@@ -1,0 +1,47 @@
+#
+# Bentobox
+# SDK - Graph
+# Preprocessors
+#
+
+import ast
+from copy import deepcopy
+from typing import Callable
+from gast import AST, Assign, AugAssign, BinOp, Load, Store
+from bento.graph.plotter import Plotter
+from bento.graph.ast import parse_ast, call_func_ast, FuncASTTransform
+
+
+def preprocess_augassign(ast: AST) -> AST:
+    """Preprocesses AugAssign into seperate assignment and binary operation AST node
+
+    Preprocesses by transforming the `AugAssign` AST node into seperate `Assign` AST
+    and binary operation AST nodes.
+
+    Example:
+        x += y => x = x + y
+
+    Args:
+        ast: AST with the AugAssign AST nodes to preprocess.
+    Returns:
+        The given ast with the AugAssign AST nodes preprocessed into separate
+        Assign and operation nodes.
+    """
+
+    def do_preprocess(ast: AST) -> AST:
+        # filter out non AugAssign AST nodes
+        if not isinstance(ast, AugAssign):
+            return ast
+        aug = ast
+        # the aug assign target is both loaded from and stored to.
+        target_store, target_load = deepcopy(aug.target), deepcopy(aug.target)
+        target_load.ctx = Load()
+        target_store.ctx = Store()
+        # transform AugAssign into Assign and BinOp
+        bin_op = BinOp(left=target_load, op=aug.op, right=aug.value)
+        return Assign(targets=[target_store], value=bin_op)
+
+    preprocess = FuncASTTransform(do_preprocess)
+    ast = preprocess.visit(ast)
+
+    return ast

--- a/sdk/bento/graph/transforms.py
+++ b/sdk/bento/graph/transforms.py
@@ -8,24 +8,7 @@ import gast
 from typing import Callable
 from gast import AST, Constant, Assign, List, Tuple
 from bento.graph.plotter import Plotter
-from bento.graph.ast import parse_ast, call_func_ast
-
-
-class FuncASTTransform(gast.NodeTransformer):
-    """Defines a AST transformation with a given transform function"""
-
-    def __init__(self, transform_fn: Callable[[AST], AST]):
-        super().__init__()
-        self.transform_fn = transform_fn
-
-    def visit(self, node: AST) -> AST:
-        # recursively visit child nodes
-        super().visit(node)
-        # on visit: transform node and fix code locations
-        new_node = gast.copy_location(new_node=self.transform_fn(node), old_node=node)
-        new_node = gast.fix_missing_locations(new_node)
-
-        return new_node
+from bento.graph.ast import parse_ast, call_func_ast, FuncASTTransform
 
 
 def transform_build_graph(ast: AST) -> AST:

--- a/sdk/tests/graph/test_preprocessors.py
+++ b/sdk/tests/graph/test_preprocessors.py
@@ -1,0 +1,56 @@
+#
+# Bentobox
+# SDK - Graph
+# Preprocessor Tests
+#
+
+import gast
+from unittest.mock import Mock
+from bento.graph.ast import parse_ast
+from bento.graph.plotter import Plotter
+from bento.graph.preprocessors import *
+
+
+def test_preprocess_augassign():
+    # test cases: line 2 is input AST, line 3 is expected output AST
+    def add_augassign_fn():
+        x, y = 1, 2
+        x += y
+        x = x + y
+
+    def sub_augassign_fn():
+        x, y = 1, 2
+        x -= y
+        x = x - y
+
+    def mul_augassign_fn():
+        x, y = 1, 2
+        x *= y
+        x = x * y
+
+    def div_augassign_fn():
+        x, y = 1, 2
+        x /= y
+        x = x / y
+
+    class C:
+        x = 1
+
+    def attribute_augassign_fn():
+        y = 1, 2
+        C.x /= y
+        C.x = C.x / y
+
+    augassign_fns = [
+        add_augassign_fn,
+        sub_augassign_fn,
+        mul_augassign_fn,
+        div_augassign_fn,
+        attribute_augassign_fn,
+    ]
+
+    for fn in augassign_fns:
+        fn_ast = parse_ast(fn).body[0]
+        aug_ast, expected_ast = fn_ast.body[1], fn_ast.body[2]
+        actual_ast = preprocess_augassign(aug_ast)
+        assert gast.dump(actual_ast) == gast.dump(expected_ast)


### PR DESCRIPTION
### What This PR Does

Add Preprocessors to Graph Compiler:
- Apply transformations to AST that run **before** static analysis  with analyzers.

Preprocess AugAssign into separate Assignment and Binary Operation:
eg.

```python
x += y
```

get preprocessed into

```python
x = x + y
```
