### PR TITLE
ci: Add clang-format to Lint and Format bentobox-sim and Protobuf Definitions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,182 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -179,5 +179,7 @@ WhitespaceSensitiveMacros:
   - STRINGIZE
   - PP_STRINGIZE
   - BOOST_PP_STRINGIZE
+---
+Language: Proto
+BasedOnStyle: Google
 ...
-

--- a/.clang-format
+++ b/.clang-format
@@ -146,7 +146,8 @@ RawStringFormats:
     CanonicalDelimiter: ''
     BasedOnStyle:    google
 ReflowComments:  true
-SortIncludes:    true
+# disable include sorting as glad.h must be imported before glfw3.h
+SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,21 +7,25 @@ name: "CI Pipeline"
 on: push
 jobs:
   # quick check that protos can be compiled by protoc
+  # and lint proto formatting
   check-protos:
     runs-on: ubuntu-20.04
-    name: "Check Protos compilable"
+    name: "Check & Lint Protos"
     env:
       PROTO_DIR: protos
     steps:
       - uses: actions/checkout@v2
-      - name: "Install protoc"
+      - name: "Install protoc & clang-format"
         run: |
           mkdir bin
-          make BIN_DIR=bin dep-protoc
+          make BIN_DIR=bin dep-protoc dep-clang-fmt
       - name: "Compile Protos with protoc"
         run: |
           ./bin/protoc -I ${PROTO_DIR} --cpp_out=/tmp ${PROTO_DIR}/bento/protos/*.proto
-
+      - name: "Lint Protos"
+        run: |
+          make lint-proto
+      
   # check spelling typos in source code
   spellcheck-code:
     runs-on: ubuntu-20.04
@@ -45,7 +49,9 @@ jobs:
     name: "Build & Test bentobox-sim"
     steps:
       - uses: actions/checkout@v2
-
+      - name: "Install clang-format"
+        run: |
+          make dep-clang-fmt
       # cache docker layers to speed up docker build
       - uses: satackey/action-docker-layer-caching@v0.0.11
         # Ignore the failure of noncritical cache step
@@ -55,7 +61,9 @@ jobs:
           key: docker-{hash}
           restore-keys: |
             docker-
-
+      - name: "Lint bentobox-sim"
+        run: |
+          make lint-sim
       - name: "Build bentobox-sim"
         run: |
           docker build -t bentobox-sim -f infra/docker/sim/Dockerfile .

--- a/makefile
+++ b/makefile
@@ -42,6 +42,7 @@ dep-clang-fmt:
 	 sudo bash -c 'echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >/etc/apt/sources.list.d/llvm.list'
 	 sudo apt-get update
 	 sudo apt-get install -y clang-format-11
+	 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 1
 
 ## Bento protobuf API
 PROTO_SRC := protos

--- a/makefile
+++ b/makefile
@@ -9,6 +9,7 @@ RM:=rm -rf
 PROTOC:=protoc
 MKDIR:=mkdir -p
 MV:=mv -f
+FIND:=find
 
 .PHONY: deps build test clean run
 
@@ -38,9 +39,12 @@ dep-protoc: /usr/local/bin/protoc
 SIM_TARGET:=bentobox
 SIM_TEST:=bentobox-test
 SIM_SRC:=sim
+SIM_SRC_DIRS:=$(SIM_SRC)/src $(SIM_SRC)/lib $(SIM_SRC)/include
 SIM_BUILD_DIR:=sim/build
+CLANG_FMT:=clang-format
+FIND_SRC:=$(FIND) $(SIM_SRC_DIRS) -type f \( -name "*.cpp" -o -name "*.h" \)
 
-.PHONY: build-sim test-sim clean-sim
+.PHONY: build-sim test-sim run-sm clean-sim format-sim
 
 build-sim:
 	$(CMAKE) -S $(SIM_SRC) -B $(SIM_BUILD_DIR) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -56,11 +60,17 @@ run-sim: build-sim
 clean-sim:
 	$(RM) $(SIM_BUILD_DIR)
 
+format-sim: .clang-format
+	$(FIND_SRC) | xargs $(CLANG_FMT) -style=file -i
+
+lint-sim: .clang-format
+	$(FIND_SRC) | xargs $(CLANG_FMT) -style=file --dry-run --Werror
+
 ## Bento - SDK component
 SDK_SRC:=sdk
 PYTHON:=python
 BLACK_FMT:=python -m black
-PYTEST:=python -m pytest
+PYTEST:=python -m pytest -s
 PDOC:=python -m pdoc
 
 .PHONY: format-sdk clean-sdk build-sdk dep-sdk-dev test-sdk lint-sdk

--- a/makefile
+++ b/makefile
@@ -25,11 +25,7 @@ format: format-proto format-sim format-sdk
 ARCH:=$(shell uname -m)
 OS:=$(if $(filter Darwin,$(shell uname -s)),osx,linux)
 BIN_DIR:=/usr/local/bin
-<<<<<<< HEAD
-deps: dep-protoc dev-sdk-dev dep-clang-fmt
-=======
-deps: dep-protoc dep-sim dev-sdk-dev
->>>>>>> master
+deps: dep-protoc dev-sdk-dev dep-clang-fmt dep-sim
 
 PROTOC_VERSION:=3.13.0
 

--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ dep-protoc: /usr/local/bin/protoc
 	$(RM) protoc-$(PROTOC_VERSION)-linux-$(ARCH).zip && $(RM) /tmp/protoc
 
 dep-clang-fmt:
-	 echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >/etc/apt/sources.list.d/llvm.list
+	 sudo bash -c 'echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >/etc/apt/sources.list.d/llvm.list'
 	 sudo apt-get update
 	 sudo apt-get install -y clang-format-11
 

--- a/makefile
+++ b/makefile
@@ -25,7 +25,7 @@ format: format-proto format-sim format-sdk
 ARCH:=$(shell uname -m)
 OS:=$(if $(filter Darwin,$(shell uname -s)),osx,linux)
 BIN_DIR:=/usr/local/bin
-deps: dep-protoc dev-sdk-dev
+deps: dep-protoc dev-sdk-dev dep-clang-fmt
 
 PROTOC_VERSION:=3.13.0
 
@@ -36,6 +36,11 @@ dep-protoc: /usr/local/bin/protoc
 	unzip -d /tmp/protoc protoc-$(PROTOC_VERSION)-linux-$(ARCH).zip 
 	$(MV) /tmp/protoc/bin/* ${BIN_DIR}
 	$(RM) protoc-$(PROTOC_VERSION)-linux-$(ARCH).zip && $(RM) /tmp/protoc
+
+dep-clang-fmt:
+	 echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >/etc/apt/sources.list.d/llvm.list
+	 sudo apt-get update
+	 sudo apt-get install -y clang-format-11
 
 ## Bento protobuf API
 PROTO_SRC := protos

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ PROTOC:=protoc
 MKDIR:=mkdir -p
 MV:=mv -f
 FIND:=find
-CLANG_FMT:=clang-format
+CLANG_FMT:=clang-format-11
 
 .PHONY: deps build test clean run
 build: build-sim build-sdk
@@ -42,7 +42,6 @@ dep-clang-fmt:
 	 sudo bash -c 'echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >/etc/apt/sources.list.d/llvm.list'
 	 sudo apt-get update
 	 sudo apt-get install -y clang-format-11
-	 sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-11 1
 
 ## Bento protobuf API
 PROTO_SRC := protos

--- a/makefile
+++ b/makefile
@@ -38,6 +38,7 @@ dep-protoc: /usr/local/bin/protoc
 	$(RM) protoc-$(PROTOC_VERSION)-linux-$(ARCH).zip && $(RM) /tmp/protoc
 
 dep-clang-fmt:
+	 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 	 sudo bash -c 'echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main\ndeb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main" >/etc/apt/sources.list.d/llvm.list'
 	 sudo apt-get update
 	 sudo apt-get install -y clang-format-11

--- a/protos/bento/protos/ecs.proto
+++ b/protos/bento/protos/ecs.proto
@@ -12,26 +12,26 @@ import "bento/protos/graph.proto";
 
 // EntityDef - registerable definition for a entity in ECS
 message EntityDef {
-    // Unique id that identifies this entity
-    // This should be auto assigned by bentobox when first registered.
-    uint32 id = 1;
-    // list of names of the components types held by this entity
-    repeated string components = 2;
+  // Unique id that identifies this entity
+  // This should be auto assigned by bentobox when first registered.
+  uint32 id = 1;
+  // list of names of the components types held by this entity
+  repeated string components = 2;
 }
 
 // ComponentDef - registerable definition for a component in ECS
 message ComponentDef {
-    // Name of the Component type
-    string name = 1;
-    // Schema definition the attributes that are held by components of this type
-    map<string, Type> schema = 2;
+  // Name of the Component type
+  string name = 1;
+  // Schema definition the attributes that are held by components of this type
+  map<string, Type> schema = 2;
 }
 
 // SystemDef - registerable definition for a system in ECS
 message SystemDef {
-    // Unique id that identifies the system.
-    // This should be auto assigned by bentobox when first registered.
-    uint32 id = 1;
-    // Computation Graph containing the implementation of the system
-    Graph graph = 2;
+  // Unique id that identifies the system.
+  // This should be auto assigned by bentobox when first registered.
+  uint32 id = 1;
+  // Computation Graph containing the implementation of the system
+  Graph graph = 2;
 }

--- a/protos/bento/protos/graph.proto
+++ b/protos/bento/protos/graph.proto
@@ -10,207 +10,210 @@ package bento.protos;
 import "bento/protos/values.proto";
 import "bento/protos/references.proto";
 
-// Node in a executable graph that represents a computable/evaluatable operation.
+// Node in a executable graph that represents a computable/evaluatable
+// operation.
 message Node {
-    // Constant - node that always outputs its held value
-    message Const {
-        // Value held by this constant
-        Value held_value = 1;
-    }
+  // Constant - node that always outputs its held value
+  message Const {
+    // Value held by this constant
+    Value held_value = 1;
+  }
 
-    /* Component access, mutation */
-    // Retrieve - node that retrieves a value from an entity's component
-    message Retrieve {
-        // Reference to the attribute to retrieve
-        AttributeRef retrieve_attr = 1;
-    }
+  /* Component access, mutation */
+  // Retrieve - node that retrieves a value from an entity's component
+  message Retrieve {
+    // Reference to the attribute to retrieve
+    AttributeRef retrieve_attr = 1;
+  }
 
-    // Mutate - node mutate the value in an entity's component based
-    // on value given by a node
-    message Mutate {
-        // node of when evaluated should provide the target value to mutate the
-        // attribute's value to
-        Node to_node = 1;
+  // Mutate - node mutate the value in an entity's component based
+  // on value given by a node
+  message Mutate {
+    // node of when evaluated should provide the target value to mutate the
+    // attribute's value to
+    Node to_node = 1;
 
-        // Reference to the attribute to mutate with value
-        AttributeRef mutate_attr = 2;
-    }
+    // Reference to the attribute to mutate with value
+    AttributeRef mutate_attr = 2;
+  }
 
-    /* Control flow */
-    // Switch - conditional evaluation based on condition in conditional  node.
-    message Switch {
-        // node that evaluates to a boolean which defines the conditional of the switch
-        Node condition_node = 1;
-        // if false, the switch will continue evaluating on the false node
-        Node false_node = 2;
-        // if true, the switch will continue evaluating on the true node
-        Node true_node = 3;
-    }
+  /* Control flow */
+  // Switch - conditional evaluation based on condition in conditional  node.
+  message Switch {
+    // node that evaluates to a boolean which defines the conditional of the
+    // switch
+    Node condition_node = 1;
+    // if false, the switch will continue evaluating on the false node
+    Node false_node = 2;
+    // if true, the switch will continue evaluating on the true node
+    Node true_node = 3;
+  }
 
-    // TODO: note: this a proposal for iteration, which might not required for MVP:
-    /*
-    // Fork - iterate/map over sequence node with map node
-    message Fork {
-        // node that evaluates to a sequence value that is iterable
-        Node sequence_node = 1;
-        // list of nodes that is evaluated for each element of the iterable value
-        // no. of nodes must match up with the no. of elements in the iterable value
-        repeated Node map_node = 2;
-    }
-    // Merge - join multiple nodes of execution by waiting all join nodes before running merged node
-    message Merge {
-        // list of nodes to wait for before executing merged node
-        repeated Node join_nodes = 1;
-        // Node that executes when join nodes finishes executing
-        Node merged_node = 2;
-    }
-    */
+  // TODO: note: this a proposal for iteration, which might not required for
+  // MVP:
+  /*
+  // Fork - iterate/map over sequence node with map node
+  message Fork {
+      // node that evaluates to a sequence value that is iterable
+      Node sequence_node = 1;
+      // list of nodes that is evaluated for each element of the iterable value
+      // no. of nodes must match up with the no. of elements in the iterable
+  value repeated Node map_node = 2;
+  }
+  // Merge - join multiple nodes of execution by waiting all join nodes before
+  running merged node message Merge {
+      // list of nodes to wait for before executing merged node
+      repeated Node join_nodes = 1;
+      // Node that executes when join nodes finishes executing
+      Node merged_node = 2;
+  }
+  */
 
-    /* Math */
-    // Arithmetic
-    message Add {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Sub {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Mul {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Div {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Max {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Min {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Abs {
-        Node x = 1;
-    }
-    message Floor {
-        Node x = 1;
-    }
-    message Ceil {
-        Node x = 1;
-    }
-    message Pow {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Mod {
-        Node x = 1;
-        Node y = 2;
-    }
-    // Trigonometry
-    message Sin {
-        Node x = 1;
-    }
-    message ArcSin {
-        Node x = 1;
-    }
-    message Cos {
-        Node x = 1;
-    }
-    message ArcCos {
-        Node x = 1;
-    }
-    message Tan {
-        Node x = 1;
-    }
-    message ArcTan {
-        Node x = 1;
-    }
-    // Random number generation
-    // returns a random float between low and high (inclusive)
-    message Random {
-        Node low = 1;
-        Node high = 2;
-    }
+  /* Math */
+  // Arithmetic
+  message Add {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Sub {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Mul {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Div {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Max {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Min {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Abs {
+    Node x = 1;
+  }
+  message Floor {
+    Node x = 1;
+  }
+  message Ceil {
+    Node x = 1;
+  }
+  message Pow {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Mod {
+    Node x = 1;
+    Node y = 2;
+  }
+  // Trigonometry
+  message Sin {
+    Node x = 1;
+  }
+  message ArcSin {
+    Node x = 1;
+  }
+  message Cos {
+    Node x = 1;
+  }
+  message ArcCos {
+    Node x = 1;
+  }
+  message Tan {
+    Node x = 1;
+  }
+  message ArcTan {
+    Node x = 1;
+  }
+  // Random number generation
+  // returns a random float between low and high (inclusive)
+  message Random {
+    Node low = 1;
+    Node high = 2;
+  }
 
-    /* Boolean */
-    message And {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Or {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Not {
-        Node x = 1;
-    }
-    message Eq {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Gt {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Lt {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Ge {
-        Node x = 1;
-        Node y = 2;
-    }
-    message Le {
-        Node x = 1;
-        Node y = 2;
-    }
+  /* Boolean */
+  message And {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Or {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Not {
+    Node x = 1;
+  }
+  message Eq {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Gt {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Lt {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Ge {
+    Node x = 1;
+    Node y = 2;
+  }
+  message Le {
+    Node x = 1;
+    Node y = 2;
+  }
 
-    // the operation that this node encapsulates
-    oneof op {
-        Const const_op = 1;
-        Retrieve retrieve_op = 2;
-        Mutate mutate_op = 3;
-        Switch switch_op = 4;
-        //Fork fork_op = 5;
-        //Merge merge_op = 6;
-        Add add_op = 7;
-        Sub sub_op = 8;
-        Mul mul_op = 9;
-        Div div_op = 10;
-        Max max_op = 11;
-        Min min_op = 12;
-        Abs abs_op = 13;
-        Floor floor_op = 14;
-        Ceil ceil_op = 15;
-        Pow pow_op = 16;
-        Mod mod_op = 17;
-        Sin sin_op = 18;
-        ArcSin arcsin_op = 19;
-        Cos cos_op = 20;
-        ArcCos arccos_op = 21;
-        Tan tan_op = 22;
-        ArcTan arctan_op = 23;
-        Random random_op = 24;
-        And and_op = 25;
-        Or or_op = 26;
-        Not not_op = 27;
-        Eq eq_op = 28;
-        Gt gt_op = 29;
-        Lt lt_op = 30;
-        Ge ge_op = 31;
-        Le le_op = 32;
-    }
+  // the operation that this node encapsulates
+  oneof op {
+    Const const_op = 1;
+    Retrieve retrieve_op = 2;
+    Mutate mutate_op = 3;
+    Switch switch_op = 4;
+    // Fork fork_op = 5;
+    // Merge merge_op = 6;
+    Add add_op = 7;
+    Sub sub_op = 8;
+    Mul mul_op = 9;
+    Div div_op = 10;
+    Max max_op = 11;
+    Min min_op = 12;
+    Abs abs_op = 13;
+    Floor floor_op = 14;
+    Ceil ceil_op = 15;
+    Pow pow_op = 16;
+    Mod mod_op = 17;
+    Sin sin_op = 18;
+    ArcSin arcsin_op = 19;
+    Cos cos_op = 20;
+    ArcCos arccos_op = 21;
+    Tan tan_op = 22;
+    ArcTan arctan_op = 23;
+    Random random_op = 24;
+    And and_op = 25;
+    Or or_op = 26;
+    Not not_op = 27;
+    Eq eq_op = 28;
+    Gt gt_op = 29;
+    Lt lt_op = 30;
+    Ge ge_op = 31;
+    Le le_op = 32;
+  }
 }
 
-// Defines a computation/evaluatable graph that takes in inputs from the component state
-// and when evaluated, mutates the component state.
+// Defines a computation/evaluatable graph that takes in inputs from the
+// component state and when evaluated, mutates the component state.
 message Graph {
-    // List of input nodes - retrieved values from component state.
-    // Input nodes must all be reachable from the output nodes
-    repeated Node.Retrieve inputs = 1;
-    // List of output nodes - mutations on the component state
-    repeated Node.Mutate outputs = 2;
+  // List of input nodes - retrieved values from component state.
+  // Input nodes must all be reachable from the output nodes
+  repeated Node.Retrieve inputs = 1;
+  // List of output nodes - mutations on the component state
+  repeated Node.Mutate outputs = 2;
 }

--- a/protos/bento/protos/references.proto
+++ b/protos/bento/protos/references.proto
@@ -8,13 +8,13 @@ syntax = "proto3";
 package bento.protos;
 
 // Fully-qualified reference to an component's attribute
-// Assumes that the component is bound the entity and attribute exists in the component type
+// Assumes that the component is bound the entity and attribute exists in the
+// component type
 message AttributeRef {
-    // id of the entity to the retrieve from
-    uint32 entity_id = 1;
-    // Name of the component type to retrieve from entity
-    string component = 2;
-    // Name of the attribute to retrieve from component
-    string attribute = 3;
+  // id of the entity to the retrieve from
+  uint32 entity_id = 1;
+  // Name of the component type to retrieve from entity
+  string component = 2;
+  // Name of the attribute to retrieve from component
+  string attribute = 3;
 }
-

--- a/protos/bento/protos/services.proto
+++ b/protos/bento/protos/services.proto
@@ -12,43 +12,43 @@ import "bento/protos/references.proto";
 import "bento/protos/sim.proto";
 
 service SimulationService {
-    // Create, Update, Get, List and Delete Simulations
-    rpc ApplySimulation(ApplySimulationReq) returns (ApplySimulationResp);
-    rpc GetSimulation(GetSimulationReq) returns (GetSimulationResp);
-    rpc ListSimulation(ListSimulationReq) returns (ListSimulationResp);
-    rpc DropSimulation(DropSimulationReq) returns (DropSimulationResp);
+  // Create, Update, Get, List and Delete Simulations
+  rpc ApplySimulation(ApplySimulationReq) returns (ApplySimulationResp);
+  rpc GetSimulation(GetSimulationReq) returns (GetSimulationResp);
+  rpc ListSimulation(ListSimulationReq) returns (ListSimulationResp);
+  rpc DropSimulation(DropSimulationReq) returns (DropSimulationResp);
 
-    // Run one step of the simulation
-    rpc StepSimulation(StepSimulationReq) returns (StepSimulationResp);
+  // Run one step of the simulation
+  rpc StepSimulation(StepSimulationReq) returns (StepSimulationResp);
 
-    // Set, Get component's Attributes
-    rpc GetAttribute(GetAttributeReq) returns (GetAttributeResp);
-    rpc SetAttribute(SetAttributeReq) returns (SetAttributeResp);
+  // Set, Get component's Attributes
+  rpc GetAttribute(GetAttributeReq) returns (GetAttributeResp);
+  rpc SetAttribute(SetAttributeReq) returns (SetAttributeResp);
 }
 
 message ApplySimulationReq {
-    // Definition of the simulation to create or apply
-    SimulationDef simulation = 1;
+  // Definition of the simulation to create or apply
+  SimulationDef simulation = 1;
 }
 message ApplySimulationResp {}
 
 message GetSimulationReq {
-    // Name of the simulation to get
-    string name = 1;
+  // Name of the simulation to get
+  string name = 1;
 }
 message GetSimulationResp {
-    SimulationDef simulation = 1;
+  SimulationDef simulation = 1;
 }
 
 message ListSimulationReq {}
 message ListSimulationResp {
-    // list of names representing all the currently registered simulations
-    repeated string sim_names = 1;
+  // list of names representing all the currently registered simulations
+  repeated string sim_names = 1;
 }
 
 message DropSimulationReq {
-    // Name of the simulation to drop
-    string name = 1;
+  // Name of the simulation to drop
+  string name = 1;
 }
 message DropSimulationResp {}
 
@@ -56,18 +56,18 @@ message StepSimulationReq {}
 message StepSimulationResp {}
 
 message GetAttributeReq {
-    // Reference to the attribute to retrieve
-    AttributeRef attribute = 1;
+  // Reference to the attribute to retrieve
+  AttributeRef attribute = 1;
 }
 message GetAttributeResp {
-    // Stored value of the requested attribute
-    Value value = 1;
+  // Stored value of the requested attribute
+  Value value = 1;
 }
 
 message SetAttributeReq {
-    // Reference to the target attribute to set
-    AttributeRef attribute = 1;
-    // The value to the set the target attribute to
-    Value value = 2;
+  // Reference to the target attribute to set
+  AttributeRef attribute = 1;
+  // The value to the set the target attribute to
+  Value value = 2;
 }
 message SetAttributeResp {}

--- a/protos/bento/protos/sim.proto
+++ b/protos/bento/protos/sim.proto
@@ -10,13 +10,13 @@ package bento.protos;
 import "bento/protos/ecs.proto";
 
 message SimulationDef {
-    // unique name that identifies this simulation
-    string name = 1;
-    // List of entities to include in this simulation
-    repeated EntityDef entities = 2;
-    // List of component types to include in this simulation
-    repeated ComponentDef components = 3;
-    // List of systems to run in this simulation.
-    // Systems would run in sequentially in the order provided in this list
-    repeated SystemDef systems = 4;
+  // unique name that identifies this simulation
+  string name = 1;
+  // List of entities to include in this simulation
+  repeated EntityDef entities = 2;
+  // List of component types to include in this simulation
+  repeated ComponentDef components = 3;
+  // List of systems to run in this simulation.
+  // Systems would run in sequentially in the order provided in this list
+  repeated SystemDef systems = 4;
 }

--- a/protos/bento/protos/types.proto
+++ b/protos/bento/protos/types.proto
@@ -9,29 +9,29 @@ package bento.protos;
 
 // Wraps data type information for all possible kinds of data types
 message Type {
-    // Defines the data types of the primitive kind
-    enum Primitive {
-        INVALID = 0;
-        BYTE    = 1;
-        INT32   = 2;
-        INT64   = 3;
-        FLOAT32 = 4;
-        FLOAT64 = 5;
-        BOOL    = 6;
-        STRING  = 7;
-    }
+  // Defines the data types of the primitive kind
+  enum Primitive {
+    INVALID = 0;
+    BYTE = 1;
+    INT32 = 2;
+    INT64 = 3;
+    FLOAT32 = 4;
+    FLOAT64 = 5;
+    BOOL = 6;
+    STRING = 7;
+  }
 
-    // Defines a array kind data type that represents an array of primitives
-    // Arrays are iterable.
-    message Array {
-        // The dimensions of the array
-        repeated int64 dimensions = 1;
-        // The primitive data type that is used to store each element
-        Primitive element_type = 2;
-    }
+  // Defines a array kind data type that represents an array of primitives
+  // Arrays are iterable.
+  message Array {
+    // The dimensions of the array
+    repeated int64 dimensions = 1;
+    // The primitive data type that is used to store each element
+    Primitive element_type = 2;
+  }
 
-    oneof kind {
-        Primitive primitive = 1;
-        Array array = 2;
-    }
+  oneof kind {
+    Primitive primitive = 1;
+    Array array = 2;
+  }
 }

--- a/protos/bento/protos/values.proto
+++ b/protos/bento/protos/values.proto
@@ -10,28 +10,28 @@ package bento.protos;
 import "bento/protos/types.proto";
 
 message Value {
-    // Data type held by this value
-    Type data_type = 1;
+  // Data type held by this value
+  Type data_type = 1;
 
-    // Defines a value of the primitive kind
-    message Primitive {
-        oneof value {
-            // primitive values
-            int32 int_32 = 1;
-            int64 int_64 = 2;
-            float float_33 = 3;
-            double float_64 = 4;
-            string str_val = 5;
-            bool boolean = 6;
-        }
+  // Defines a value of the primitive kind
+  message Primitive {
+    oneof value {
+      // primitive values
+      int32 int_32 = 1;
+      int64 int_64 = 2;
+      float float_33 = 3;
+      double float_64 = 4;
+      string str_val = 5;
+      bool boolean = 6;
     }
-    // Defines a value of the array kind
-    message Array {
-        repeated Primitive values = 1;
-    }
+  }
+  // Defines a value of the array kind
+  message Array {
+    repeated Primitive values = 1;
+  }
 
-    oneof kind {
-        Primitive primitive = 2;
-        Array array = 3;
-    }
+  oneof kind {
+    Primitive primitive = 2;
+    Array array = 3;
+  }
 }

--- a/sim/include/component/pos1DComponent.h
+++ b/sim/include/component/pos1DComponent.h
@@ -2,11 +2,11 @@
 #define BENTOBOX_POS1DCOMPONENT_H
 
 namespace ics::component {
-    struct Pos1DComponent : public ics::BaseComponent {
-        unsigned int x;
+struct Pos1DComponent : public ics::BaseComponent {
+    unsigned int x;
 
-        explicit Pos1DComponent(unsigned int x) : x(x) {}
-    };
-}
+    explicit Pos1DComponent(unsigned int x) : x(x) {}
+};
+}  // namespace ics::component
 
-#endif //BENTOBOX_POS1DCOMPONENT_H
+#endif  // BENTOBOX_POS1DCOMPONENT_H

--- a/sim/include/component/pos2DComponent.h
+++ b/sim/include/component/pos2DComponent.h
@@ -2,12 +2,12 @@
 #define BENTOBOX_POS2DCOMPONENT_H
 
 namespace ics::component {
-    struct Pos2DComponent : public ics::BaseComponent {
-        unsigned int x;
-        unsigned int y;
+struct Pos2DComponent : public ics::BaseComponent {
+    unsigned int x;
+    unsigned int y;
 
-        explicit Pos1DComponent(unsigned int x, unsigned int y) : x(x), y(y) {}
-    };
-}
+    explicit Pos1DComponent(unsigned int x, unsigned int y) : x(x), y(y) {}
+};
+}  // namespace ics::component
 
-#endif //BENTOBOX_POS2DCOMPONENT_H
+#endif  // BENTOBOX_POS2DCOMPONENT_H

--- a/sim/include/component/textureComponent.h
+++ b/sim/include/component/textureComponent.h
@@ -4,11 +4,11 @@
 #include <core/ics/component.h>
 
 namespace ics::component {
-    struct Texture2DComponent : public ics::BaseComponent {
-        unsigned int texture;
+struct Texture2DComponent : public ics::BaseComponent {
+    unsigned int texture;
 
-        explicit Texture2DComponent(unsigned int texture) : texture(texture) {}
-    };
-}
+    explicit Texture2DComponent(unsigned int texture) : texture(texture) {}
+};
+}  // namespace ics::component
 
-#endif //BENTOBOX_TEXTURECOMPONENT_H
+#endif  // BENTOBOX_TEXTURECOMPONENT_H

--- a/sim/include/ics.h
+++ b/sim/include/ics.h
@@ -7,17 +7,18 @@
 #include <index/indexStore.h>
 
 namespace ics {
-    template<Component C>
-    CompStoreId addComponent(index::IndexStore& indexStore, ComponentStore& compStore, const C& c) {
-        auto& compTypeIndex = indexStore.componentType;
+template <Component C>
+CompStoreId addComponent(index::IndexStore& indexStore,
+                         ComponentStore& compStore, const C& c) {
+    auto& compTypeIndex = indexStore.componentType;
 
-        // Update the ComponentType index
-        auto compIndex = compTypeIndex.addComponentType<C>();
-        // Add the component to the component store
-        auto compId = addComponent(compStore, c, compIndex);
+    // Update the ComponentType index
+    auto compIndex = compTypeIndex.addComponentType<C>();
+    // Add the component to the component store
+    auto compId = addComponent(compStore, c, compIndex);
 
-        return compId;
-    }
+    return compId;
 }
+}  // namespace ics
 
-#endif //BENTOBOX_COMPONENTSTOREEXT_H
+#endif  // BENTOBOX_COMPONENTSTOREEXT_H

--- a/sim/include/index/componentType.h
+++ b/sim/include/index/componentType.h
@@ -1,66 +1,66 @@
 #ifndef BENTOBOX_COMPONENTTYPEINDEX_H
 #define BENTOBOX_COMPONENTTYPEINDEX_H
 
-#include <unordered_map>
-#include <functional>
 #include <core/ics/component.h>
 #include <core/ics/componentSet.h>
 
+#include <functional>
+#include <unordered_map>
+
 namespace ics::index {
-    class ComponentType {
-    private:
-        std::unordered_map<std::type_index, CompGroup> typeGroupMap;
-        CompGroup compGroup = 0;
+class ComponentType {
+   private:
+    std::unordered_map<std::type_index, CompGroup> typeGroupMap;
+    CompGroup compGroup = 0;
 
-    public:
-        template<Component C>
-        // The return type is left as auto so that the capturing lambda is properly
-        // represented. Type errors can occur at build-time when using function
-        // pointer return types or std::function.
-        auto is() {
-            auto compIndex = typeGroupMap.at(std::type_index(typeid(C)));
+   public:
+    template <Component C>
+    // The return type is left as auto so that the capturing lambda is properly
+    // represented. Type errors can occur at build-time when using function
+    // pointer return types or std::function.
+    auto is() {
+        auto compIndex = typeGroupMap.at(std::type_index(typeid(C)));
 
-            return [compIndex](const ics::ComponentSet& compSet) {
-                // TODO(joeltio): find a way to make this more memory efficient
-                ics::ComponentSet newSet;
-                for (const CompStoreId& comp : compSet) {
-                    if (comp.first == compIndex) {
-                        newSet.insert(comp);
-                    }
+        return [compIndex](const ics::ComponentSet& compSet) {
+            // TODO(joeltio): find a way to make this more memory efficient
+            ics::ComponentSet newSet;
+            for (const CompStoreId& comp : compSet) {
+                if (comp.first == compIndex) {
+                    newSet.insert(comp);
                 }
-
-                return newSet;
-            };
-        }
-
-        template<Component C>
-        bool hasComponentType() {
-            auto compType = std::type_index(typeid(C));
-            return typeGroupMap.contains(compType);
-        }
-
-        template<Component C>
-        CompGroup addComponentType() {
-            auto compType = std::type_index(typeid(C));
-            if (!typeGroupMap.contains(compType)) {
-                typeGroupMap.insert(std::make_pair(compType, compGroup));
-
-                // Equivalent to return compGroup++;
-                auto insertedCompGroup = compGroup;
-                ++compGroup;
-                return insertedCompGroup;
             }
 
-            return typeGroupMap.at(compType);
+            return newSet;
+        };
+    }
+
+    template <Component C>
+    bool hasComponentType() {
+        auto compType = std::type_index(typeid(C));
+        return typeGroupMap.contains(compType);
+    }
+
+    template <Component C>
+    CompGroup addComponentType() {
+        auto compType = std::type_index(typeid(C));
+        if (!typeGroupMap.contains(compType)) {
+            typeGroupMap.insert(std::make_pair(compType, compGroup));
+
+            // Equivalent to return compGroup++;
+            auto insertedCompGroup = compGroup;
+            ++compGroup;
+            return insertedCompGroup;
         }
 
-        template<Component C>
-        CompGroup getComponentType() {
-            auto compType = std::type_index(typeid(C));
-            return typeGroupMap.at(compType);
-        }
-    };
-}
+        return typeGroupMap.at(compType);
+    }
 
+    template <Component C>
+    CompGroup getComponentType() {
+        auto compType = std::type_index(typeid(C));
+        return typeGroupMap.at(compType);
+    }
+};
+}  // namespace ics::index
 
-#endif //BENTOBOX_COMPONENTTYPEINDEX_H
+#endif  // BENTOBOX_COMPONENTTYPEINDEX_H

--- a/sim/include/index/indexStore.h
+++ b/sim/include/index/indexStore.h
@@ -4,9 +4,9 @@
 #include "componentType.h"
 
 namespace ics::index {
-    struct IndexStore {
-        ComponentType componentType;
-    };
-}
+struct IndexStore {
+    ComponentType componentType;
+};
+}  // namespace ics::index
 
-#endif //BENTOBOX_INDEXSTORE_H
+#endif  // BENTOBOX_INDEXSTORE_H

--- a/sim/include/system/render.h
+++ b/sim/include/system/render.h
@@ -6,7 +6,9 @@
 #include <index/indexStore.h>
 
 namespace ics::system {
-    void render(GraphicsContext& graphicsContext, ics::ComponentStore& componentStore, ics::index::IndexStore& indexStore);
+void render(GraphicsContext& graphicsContext,
+            ics::ComponentStore& componentStore,
+            ics::index::IndexStore& indexStore);
 }
 
-#endif //BENTOBOX_RENDER_H
+#endif  // BENTOBOX_RENDER_H

--- a/sim/lib/core/include/core/graphicsContext.h
+++ b/sim/lib/core/include/core/graphicsContext.h
@@ -3,12 +3,14 @@
 
 #include <string>
 #include <unordered_map>
+
 #include "windowContext.h"
 
 class GraphicsContext {
-private:
+   private:
     std::unordered_map<std::string, unsigned int> textureCache;
-public:
+
+   public:
     GraphicsContext(WindowContext& windowContext);
     ~GraphicsContext();
     GraphicsContext(const GraphicsContext& other) = default;
@@ -19,4 +21,4 @@ public:
     unsigned int loadTexture2D(std::string const& filepath);
 };
 
-#endif //BENTOBOX_GRAPHICSCONTEXT_H
+#endif  // BENTOBOX_GRAPHICSCONTEXT_H

--- a/sim/lib/core/include/core/ics/compVec.h
+++ b/sim/lib/core/include/core/ics/compVec.h
@@ -2,121 +2,133 @@
 #define BENTOBOX_COMPVEC_H
 
 #include <any>
-#include <vector>
-#include <queue>
-#include <memory>
 #include <functional>
+#include <iostream>
+#include <memory>
+#include <queue>
 #include <typeindex>
 #include <unordered_map>
-#include <iostream>
+#include <vector>
 
 #include "component.h"
 
 namespace ics {
-    typedef unsigned long CompId;
+typedef unsigned long CompId;
 
-    template<Component C>
-    class CompVec {
-    public:
-        typedef typename std::vector<C>::size_type size_type;
-    private:
-        CompId lastId = 0;
-        std::function<C&(std::vector<BaseComponent>* vectorPtr, size_type idx)> getter;
-        std::function<const C&(const std::vector<BaseComponent>* vectorPtr, size_type idx)> constGetter;
-        std::unordered_map<CompId, size_type> idToIndex;
-        std::queue<size_type> inactiveCompIdx;
-        std::vector<C> vec;
-    protected:
-        void isActiveCheck(CompId id) const;
-        size_type addToVec(const C& val);
-    public:
-        CompVec() {
-            getter = [](std::vector<BaseComponent>* vectorPtr, size_type idx) -> C& {
-                auto vecPtr = reinterpret_cast<std::vector<C>*>(vectorPtr);
-                return vecPtr->at(idx);
-            };
+template <Component C>
+class CompVec {
+   public:
+    typedef typename std::vector<C>::size_type size_type;
 
-            constGetter = [](const std::vector<BaseComponent>* vectorPtr, size_type idx) -> const C& {
-                const auto vecPtr = reinterpret_cast<const std::vector<C>*>(vectorPtr);
-                return vecPtr->at(idx);
-            };
-        }
-        CompId add(const C& val);
-        void remove(CompId id);
-        size_type size();
+   private:
+    CompId lastId = 0;
+    std::function<C&(std::vector<BaseComponent>* vectorPtr, size_type idx)>
+        getter;
+    std::function<const C&(const std::vector<BaseComponent>* vectorPtr,
+                           size_type idx)>
+        constGetter;
+    std::unordered_map<CompId, size_type> idToIndex;
+    std::queue<size_type> inactiveCompIdx;
+    std::vector<C> vec;
 
-        C& at(CompId id);
-        C& operator[](CompId id);
-        const C& operator[](CompId id) const;
-    };
+   protected:
+    void isActiveCheck(CompId id) const;
+    size_type addToVec(const C& val);
 
-    template<Component C>
-    void CompVec<C>::isActiveCheck(CompId id) const {
-        auto index = idToIndex.at(id);
-        const auto& comp = constGetter(reinterpret_cast<const std::vector<BaseComponent>*>(&vec), index);
-        if (!comp.isActive) {
-            // TODO(joeltio): format the index into the string
-            throw std::out_of_range("compVec::isActiveCheck: component at index is inactive");
-        }
+   public:
+    CompVec() {
+        getter = [](std::vector<BaseComponent>* vectorPtr,
+                    size_type idx) -> C& {
+            auto vecPtr = reinterpret_cast<std::vector<C>*>(vectorPtr);
+            return vecPtr->at(idx);
+        };
+
+        constGetter = [](const std::vector<BaseComponent>* vectorPtr,
+                         size_type idx) -> const C& {
+            const auto vecPtr =
+                reinterpret_cast<const std::vector<C>*>(vectorPtr);
+            return vecPtr->at(idx);
+        };
     }
+    CompId add(const C& val);
+    void remove(CompId id);
+    size_type size();
 
-    template<Component C>
-    typename CompVec<C>::size_type CompVec<C>::addToVec(const C& val) {
-        if (!this->inactiveCompIdx.empty()) {
-            // Reuse old component space
-            CompVec<C>::size_type insertIdx = this->inactiveCompIdx.front();
-            this->vec.at(insertIdx) = val;
-            this->inactiveCompIdx.pop();
-            return insertIdx;
-        } else {
-            this->vec.push_back(val);
-            return vec.size() - 1;
-        }
-    }
+    C& at(CompId id);
+    C& operator[](CompId id);
+    const C& operator[](CompId id) const;
+};
 
-    template<Component C>
-    CompId CompVec<C>::add(const C& val) {
-        auto insertedIdx = addToVec(val);
-        // Update the idToIndex map
-        idToIndex.insert(std::make_pair(lastId + 1, insertedIdx));
-        ++lastId;
-        return lastId;
-    }
-
-    template<Component C>
-    void CompVec<C>::remove(CompId id) {
-        auto index = idToIndex.at(id);
-        // Mark component as deleted
-        auto& comp = getter(reinterpret_cast<std::vector<BaseComponent>*>(&vec), index);
-        comp.isActive = false;
-        // Queue the component for reuse
-        inactiveCompIdx.push(index);
-        // Remove the mapping from idToIdx
-        idToIndex.erase(id);
-    }
-
-    template<Component C>
-    typename CompVec<C>::size_type CompVec<C>::size() {
-        return idToIndex.size();
-    }
-
-    template<Component C>
-    C& CompVec<C>::at(CompId id) {
-        isActiveCheck(id);
-        auto index = idToIndex.at(id);
-
-        return getter(reinterpret_cast<std::vector<BaseComponent>*>(&vec), index);
-    }
-
-    template<Component C>
-    const C& CompVec<C>::operator[](CompId id) const {
-        return this->at(id);
-    }
-
-    template<Component C>
-    C& CompVec<C>::operator[](CompId id) {
-        return this->at(id);
+template <Component C>
+void CompVec<C>::isActiveCheck(CompId id) const {
+    auto index = idToIndex.at(id);
+    const auto& comp = constGetter(
+        reinterpret_cast<const std::vector<BaseComponent>*>(&vec), index);
+    if (!comp.isActive) {
+        // TODO(joeltio): format the index into the string
+        throw std::out_of_range(
+            "compVec::isActiveCheck: component at index is inactive");
     }
 }
 
-#endif //BENTOBOX_COMPVEC_H
+template <Component C>
+typename CompVec<C>::size_type CompVec<C>::addToVec(const C& val) {
+    if (!this->inactiveCompIdx.empty()) {
+        // Reuse old component space
+        CompVec<C>::size_type insertIdx = this->inactiveCompIdx.front();
+        this->vec.at(insertIdx) = val;
+        this->inactiveCompIdx.pop();
+        return insertIdx;
+    } else {
+        this->vec.push_back(val);
+        return vec.size() - 1;
+    }
+}
+
+template <Component C>
+CompId CompVec<C>::add(const C& val) {
+    auto insertedIdx = addToVec(val);
+    // Update the idToIndex map
+    idToIndex.insert(std::make_pair(lastId + 1, insertedIdx));
+    ++lastId;
+    return lastId;
+}
+
+template <Component C>
+void CompVec<C>::remove(CompId id) {
+    auto index = idToIndex.at(id);
+    // Mark component as deleted
+    auto& comp =
+        getter(reinterpret_cast<std::vector<BaseComponent>*>(&vec), index);
+    comp.isActive = false;
+    // Queue the component for reuse
+    inactiveCompIdx.push(index);
+    // Remove the mapping from idToIdx
+    idToIndex.erase(id);
+}
+
+template <Component C>
+typename CompVec<C>::size_type CompVec<C>::size() {
+    return idToIndex.size();
+}
+
+template <Component C>
+C& CompVec<C>::at(CompId id) {
+    isActiveCheck(id);
+    auto index = idToIndex.at(id);
+
+    return getter(reinterpret_cast<std::vector<BaseComponent>*>(&vec), index);
+}
+
+template <Component C>
+const C& CompVec<C>::operator[](CompId id) const {
+    return this->at(id);
+}
+
+template <Component C>
+C& CompVec<C>::operator[](CompId id) {
+    return this->at(id);
+}
+}  // namespace ics
+
+#endif  // BENTOBOX_COMPVEC_H

--- a/sim/lib/core/include/core/ics/component.h
+++ b/sim/lib/core/include/core/ics/component.h
@@ -4,16 +4,16 @@
 #include <concepts>
 
 namespace ics {
-    struct BaseComponent {
-        // isActive is used for memory pooling. When a component is marked as
-        // inactive, it is "deleted". The memory used by inactive components
-        // will be reused.
-        bool isActive = true;
-        bool operator==(const BaseComponent&) const = default;
-    };
+struct BaseComponent {
+    // isActive is used for memory pooling. When a component is marked as
+    // inactive, it is "deleted". The memory used by inactive components
+    // will be reused.
+    bool isActive = true;
+    bool operator==(const BaseComponent&) const = default;
+};
 
-    template<class C>
-    concept Component = std::derived_from<C, BaseComponent>;
-}
+template <class C>
+concept Component = std::derived_from<C, BaseComponent>;
+}  // namespace ics
 
-#endif //BENTOBOX_COMPONENT_H
+#endif  // BENTOBOX_COMPONENT_H

--- a/sim/lib/core/include/core/ics/componentSet.h
+++ b/sim/lib/core/include/core/ics/componentSet.h
@@ -2,24 +2,24 @@
 #define BENTOBOX_COMPONENTSET_H
 
 #include <unordered_set>
+
 #include "compVec.h"
 
 namespace ics {
-    typedef size_t CompGroup;
-    typedef std::pair<CompGroup, CompId> CompStoreId;
-    typedef std::unordered_set<CompStoreId, std::hash<CompStoreId>> ComponentSet;
-}
+typedef size_t CompGroup;
+typedef std::pair<CompGroup, CompId> CompStoreId;
+typedef std::unordered_set<CompStoreId, std::hash<CompStoreId>> ComponentSet;
+}  // namespace ics
 
 namespace std {
-    // std::unordered_set does not know how to hash CompStoreId. This function
-    // tells C++ how to do so.
-    template <> struct hash<ics::CompStoreId> {
-        inline size_t operator()(const ics::CompStoreId &v) const {
-            return v.first * 31 + v.second;
-        }
-    };
-}
+// std::unordered_set does not know how to hash CompStoreId. This function
+// tells C++ how to do so.
+template <>
+struct hash<ics::CompStoreId> {
+    inline size_t operator()(const ics::CompStoreId &v) const {
+        return v.first * 31 + v.second;
+    }
+};
+}  // namespace std
 
-
-
-#endif //BENTOBOX_COMPONENTSET_H
+#endif  // BENTOBOX_COMPONENTSET_H

--- a/sim/lib/core/include/core/ics/componentStore.h
+++ b/sim/lib/core/include/core/ics/componentStore.h
@@ -1,52 +1,54 @@
 #ifndef BENTOBOX_COMPONENTSTORE_H
 #define BENTOBOX_COMPONENTSTORE_H
 
-#include <unordered_map>
-#include <memory>
 #include <any>
-#include "component.h"
+#include <memory>
+#include <unordered_map>
+
 #include "compVec.h"
+#include "component.h"
 #include "componentSet.h"
 
 namespace ics {
-    // stores size_t -> unique_ptr -> CompVec<Component>
-    // stored as size_t -> unique_ptr -> any(CompVec<BaseComponent>)
-    typedef std::unordered_map<CompGroup, std::unique_ptr<CompVec<BaseComponent>>> ComponentStore;
+// stores size_t -> unique_ptr -> CompVec<Component>
+// stored as size_t -> unique_ptr -> any(CompVec<BaseComponent>)
+typedef std::unordered_map<CompGroup, std::unique_ptr<CompVec<BaseComponent>>>
+    ComponentStore;
 
-    template<Component C>
-    CompVec<C>& getCompVec(ComponentStore& store, CompGroup group) {
-        auto& compVec = *store.at(group);
-        auto& castedCompVec = *reinterpret_cast<ics::CompVec<C>*>(&compVec);
-        return castedCompVec;
-    }
-
-    template<Component C>
-    CompVec<C>& createCompVec(ComponentStore& store, CompGroup group) {
-        ics::CompVec<C> vec;
-        ics::CompVec<BaseComponent> castedVec = *reinterpret_cast<ics::CompVec<BaseComponent>*>(&vec);
-
-        store.emplace(
-            group,
-            std::make_unique<ics::CompVec<BaseComponent>>(castedVec)
-        );
-
-        return getCompVec<C>(store, group);
-    }
-
-    template<Component C>
-    CompStoreId addComponent(ComponentStore& store, const C& c, CompGroup group) {
-        auto& vec = store.contains(group) ? getCompVec<C>(store, group) : createCompVec<C>(store, group);
-        auto vecIndex = vec.add(c);
-        return std::make_pair(group, vecIndex);
-    }
-
-    template<Component C>
-    C& getComponent(ComponentStore& store, CompStoreId compStoreId) {
-        auto& vec = getCompVec<C>(store, compStoreId.first);
-        return vec.at(compStoreId.second);
-    }
-
-    ComponentSet asCompSet(const ComponentStore& store);
+template <Component C>
+CompVec<C>& getCompVec(ComponentStore& store, CompGroup group) {
+    auto& compVec = *store.at(group);
+    auto& castedCompVec = *reinterpret_cast<ics::CompVec<C>*>(&compVec);
+    return castedCompVec;
 }
 
-#endif //BENTOBOX_COMPONENTSTORE_H
+template <Component C>
+CompVec<C>& createCompVec(ComponentStore& store, CompGroup group) {
+    ics::CompVec<C> vec;
+    ics::CompVec<BaseComponent> castedVec =
+        *reinterpret_cast<ics::CompVec<BaseComponent>*>(&vec);
+
+    store.emplace(group,
+                  std::make_unique<ics::CompVec<BaseComponent>>(castedVec));
+
+    return getCompVec<C>(store, group);
+}
+
+template <Component C>
+CompStoreId addComponent(ComponentStore& store, const C& c, CompGroup group) {
+    auto& vec = store.contains(group) ? getCompVec<C>(store, group)
+                                      : createCompVec<C>(store, group);
+    auto vecIndex = vec.add(c);
+    return std::make_pair(group, vecIndex);
+}
+
+template <Component C>
+C& getComponent(ComponentStore& store, CompStoreId compStoreId) {
+    auto& vec = getCompVec<C>(store, compStoreId.first);
+    return vec.at(compStoreId.second);
+}
+
+ComponentSet asCompSet(const ComponentStore& store);
+}  // namespace ics
+
+#endif  // BENTOBOX_COMPONENTSTORE_H

--- a/sim/lib/core/include/core/ics/util/composable.h
+++ b/sim/lib/core/include/core/ics/util/composable.h
@@ -5,21 +5,23 @@
 #include <variant>
 
 namespace util {
-    template<class Data>
-    class Composable {
-    public:
-        const Data data;
-        explicit Composable(Data d) : data(d) {};
+template <class Data>
+class Composable {
+   public:
+    const Data data;
+    explicit Composable(Data d) : data(d){};
 
-        template<class Fn>
-        // Require that Fn is a function that has argument of type Data, i.e. Fn: (Data d) -> ??
-        requires std::invocable<Fn, Data>
+    template <class Fn>
+    // Require that Fn is a function that has argument of type Data, i.e. Fn:
+    // (Data d) -> ??
+    requires std::invocable<Fn, Data>
         // The return type is Composable<Return type of Fn(Data)>
-        auto operator|(Fn fn) -> Composable<decltype(fn(std::declval<Data>()))> {
-            typedef decltype(fn(std::declval<Data>())) ReturnType;
-            return Composable<ReturnType>(fn(data));
-        }
-    };
-}
+        auto operator|(Fn fn)
+            -> Composable<decltype(fn(std::declval<Data>()))> {
+        typedef decltype(fn(std::declval<Data>())) ReturnType;
+        return Composable<ReturnType>(fn(data));
+    }
+};
+}  // namespace util
 
-#endif //BENTOBOX_COMPOSABLE_H
+#endif  // BENTOBOX_COMPOSABLE_H

--- a/sim/lib/core/include/core/ics/util/typeMap.h
+++ b/sim/lib/core/include/core/ics/util/typeMap.h
@@ -2,33 +2,33 @@
 #define BENTOBOX_TYPEMAP_H
 
 #include <any>
-#include <unordered_map>
 #include <typeindex>
+#include <unordered_map>
 
 namespace util {
-    class TypeMap {
-    private:
-        std::unordered_map<std::type_index, std::any> map;
-    public:
-        template<typename T>
-        T& at() {
-            auto type = std::type_index(typeid(T));
-            return std::any_cast<T&>(map.at(type));
-        };
+class TypeMap {
+   private:
+    std::unordered_map<std::type_index, std::any> map;
 
-        template<typename T>
-        void insert(const T& value) {
-            auto type = std::type_index(typeid(T));
-            map.insert(std::make_pair(type, value));
-        }
-
-        template<typename T>
-        bool has() const {
-            auto type = std::type_index(typeid(T));
-            return map.find(type) != map.end();
-        }
+   public:
+    template <typename T>
+    T& at() {
+        auto type = std::type_index(typeid(T));
+        return std::any_cast<T&>(map.at(type));
     };
-}
 
+    template <typename T>
+    void insert(const T& value) {
+        auto type = std::type_index(typeid(T));
+        map.insert(std::make_pair(type, value));
+    }
 
-#endif //BENTOBOX_TYPEMAP_H
+    template <typename T>
+    bool has() const {
+        auto type = std::type_index(typeid(T));
+        return map.find(type) != map.end();
+    }
+};
+}  // namespace util
+
+#endif  // BENTOBOX_TYPEMAP_H

--- a/sim/lib/core/include/core/systemContext.h
+++ b/sim/lib/core/include/core/systemContext.h
@@ -3,25 +3,28 @@
 
 #include <forward_list>
 #include <functional>
-#include "ics/componentStore.h"
+
 #include "graphicsContext.h"
+#include "ics/componentStore.h"
 
 namespace {
-    template<class C>
-    concept IndexStore = std::semiregular<C> && !std::is_fundamental_v<C>;
+template <class C>
+concept IndexStore = std::semiregular<C> && !std::is_fundamental_v<C>;
 }
 
-template<IndexStore IS>
-using SystemFn = std::function<void(GraphicsContext&, ics::ComponentStore&, IS&)>;
+template <IndexStore IS>
+using SystemFn =
+    std::function<void(GraphicsContext&, ics::ComponentStore&, IS&)>;
 
-template<IndexStore IS>
+template <IndexStore IS>
 struct SystemContext {
     std::forward_list<SystemFn<IS>> systems;
-    void run(GraphicsContext& graphicsContext, ics::ComponentStore& componentStore, IS& indexStore) {
+    void run(GraphicsContext& graphicsContext,
+             ics::ComponentStore& componentStore, IS& indexStore) {
         for (const auto& system : systems) {
             system(graphicsContext, componentStore, indexStore);
         }
     }
 };
 
-#endif //BENTOBOX_SYSTEMCONTEXT_H
+#endif  // BENTOBOX_SYSTEMCONTEXT_H

--- a/sim/lib/core/include/core/windowContext.h
+++ b/sim/lib/core/include/core/windowContext.h
@@ -5,11 +5,12 @@
 #include <GLFW/glfw3.h>
 
 class WindowContext {
-private:
+   private:
     int width;
     int height;
     const char* title;
-public:
+
+   public:
     GLFWwindow* window = nullptr;
 
     WindowContext(int width, int height, const char* title);
@@ -24,4 +25,4 @@ public:
     void swapBuffers() const;
 };
 
-#endif //BENTOBOX_WINDOWCONTEXT_H
+#endif  // BENTOBOX_WINDOWCONTEXT_H

--- a/sim/lib/core/src/graphicsContext.cpp
+++ b/sim/lib/core/src/graphicsContext.cpp
@@ -1,11 +1,13 @@
 #define STB_IMAGE_IMPLEMENTATION
 
-#include <stb_image.h>
-#include <stdexcept>
 #include <core/graphicsContext.h>
+#include <stb_image.h>
 
-GraphicsContext::GraphicsContext(WindowContext& windowContext) : windowContext(windowContext) {
-    if (!gladLoadGLLoader((GLADloadproc) glfwGetProcAddress)) {
+#include <stdexcept>
+
+GraphicsContext::GraphicsContext(WindowContext& windowContext)
+    : windowContext(windowContext) {
+    if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
         throw "Failed to initialise GLAD";
     }
 }
@@ -20,13 +22,14 @@ GraphicsContext::~GraphicsContext() {
 
 // The default copy assignment is unable to assign references, hence they must
 // be explicitly defined. The linting is disabled for this reason.
-GraphicsContext& GraphicsContext::operator=(const GraphicsContext &other) { // NOLINT(modernize-use-equals-default)
+GraphicsContext& GraphicsContext::operator=(
+    const GraphicsContext& other) {  // NOLINT(modernize-use-equals-default)
     windowContext = other.windowContext;
     textureCache = other.textureCache;
     return *this;
 }
 
-unsigned int GraphicsContext::loadTexture2D(const std::string &filepath) {
+unsigned int GraphicsContext::loadTexture2D(const std::string& filepath) {
     if (textureCache.find(filepath) != textureCache.end()) {
         return textureCache[filepath];
     }
@@ -41,19 +44,24 @@ unsigned int GraphicsContext::loadTexture2D(const std::string &filepath) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
     int width, height, nrChannels;
-    unsigned char *data = stbi_load(filepath.c_str(), &width, &height, &nrChannels, 0);
+    unsigned char* data =
+        stbi_load(filepath.c_str(), &width, &height, &nrChannels, 0);
 
     if (!data) {
-        // TODO(joeltio): Replace with a logger class and add name of texture that failed to load
+        // TODO(joeltio): Replace with a logger class and add name of texture
+        // that failed to load
         throw std::runtime_error("Failed to load texture.");
     }
 
     if (nrChannels == 4) {
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+                     GL_UNSIGNED_BYTE, data);
     } else if (nrChannels == 3) {
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB,
+                     GL_UNSIGNED_BYTE, data);
     } else {
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RED, GL_UNSIGNED_BYTE, data);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RED,
+                     GL_UNSIGNED_BYTE, data);
     }
 
     glGenerateMipmap(GL_TEXTURE_2D);

--- a/sim/lib/core/src/ics/compVec.test.cpp
+++ b/sim/lib/core/src/ics/compVec.test.cpp
@@ -1,7 +1,8 @@
-#include <gtest/gtest.h>
-#include <any>
-#include <core/ics/component.h>
 #include <core/ics/compVec.h>
+#include <core/ics/component.h>
+#include <gtest/gtest.h>
+
+#include <any>
 
 #define TEST_SUITE CompVecTest
 
@@ -13,7 +14,7 @@ struct TestComp : public BaseComponent {
 
 TEST(TEST_SUITE, StoreAndRetrieve) {
     auto vec = CompVec<TestComp>();
-    auto id = vec.add(TestComp { true, 3 });
+    auto id = vec.add(TestComp{true, 3});
 
     TestComp value = vec.at(id);
     ASSERT_EQ(value.height, 3);
@@ -21,24 +22,15 @@ TEST(TEST_SUITE, StoreAndRetrieve) {
 
 TEST(TEST_SUITE, RetrieveNonExistentComponent) {
     auto vec = CompVec<TestComp>();
-    EXPECT_THROW(
-        vec.at(0),
-        std::out_of_range
-    );
+    EXPECT_THROW(vec.at(0), std::out_of_range);
 }
 
 TEST(TEST_SUITE, RetrieveDeletedComponent) {
     auto vec = CompVec<TestComp>();
-    auto id = vec.add(TestComp{ true, 3 });
+    auto id = vec.add(TestComp{true, 3});
     vec.remove(id);
-    EXPECT_THROW(
-        vec.at(id),
-        std::out_of_range
-    );
-    EXPECT_THROW(
-        vec[id],
-        std::out_of_range
-    );
+    EXPECT_THROW(vec.at(id), std::out_of_range);
+    EXPECT_THROW(vec[id], std::out_of_range);
 }
 
 TEST(TEST_SUITE, RetrieveByReference) {
@@ -67,12 +59,12 @@ TEST(TEST_SUITE, RetrieveByReference) {
 
 TEST(TEST_SUITE, StoreAsUnknownAndRetrieve) {
     auto vec = CompVec<TestComp>();
-    auto trueCompId = vec.add(TestComp { true, 3 });
-    auto falseCompId = vec.add(TestComp { false, 3 });
-    vec.add(TestComp { true, 3 });
-    CompVec<TestComp>* vecPtr = &vec;
+    auto trueCompId = vec.add(TestComp{true, 3});
+    auto falseCompId = vec.add(TestComp{false, 3});
+    vec.add(TestComp{true, 3});
+    CompVec<TestComp> *vecPtr = &vec;
 
-    auto storedVec = reinterpret_cast<CompVec<BaseComponent>*>(vecPtr);
+    auto storedVec = reinterpret_cast<CompVec<BaseComponent> *>(vecPtr);
 
     ASSERT_EQ(storedVec->size(), 3);
     ASSERT_TRUE(storedVec->at(trueCompId).isActive);

--- a/sim/lib/core/src/ics/component.test.cpp
+++ b/sim/lib/core/src/ics/component.test.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <core/ics/component.h>
+#include <gtest/gtest.h>
 
 #define TEST_SUITE Component
 
@@ -11,12 +11,12 @@ struct DerivedComp : public BaseComponent {
 };
 
 TEST(TEST_SUITE, DerivedComponentsEquivalence) {
-    auto d1 = DerivedComp {
+    auto d1 = DerivedComp{
         .height = 3,
         .c = 'c',
     };
 
-    auto d2 = DerivedComp {
+    auto d2 = DerivedComp{
         .height = 3,
         .c = 'c',
     };

--- a/sim/lib/core/src/ics/componentStore.cpp
+++ b/sim/lib/core/src/ics/componentStore.cpp
@@ -1,17 +1,18 @@
 #include <core/ics/componentStore.h>
 
 namespace ics {
-    ComponentSet asCompSet(const ComponentStore &store) {
-        ComponentSet set;
-        for (auto &index_ptr_pair : store) {
-            auto& a = *index_ptr_pair.second;
-            // TODO(joeltio): This requires knowledge on how CompVec creates IDs. Add
-            // TODO(joeltio): iter functionality for compVec
-            for (auto i = 1; i <= a.size(); ++i) {
-                set.emplace(index_ptr_pair.first, i);
-            }
+ComponentSet asCompSet(const ComponentStore &store) {
+    ComponentSet set;
+    for (auto &index_ptr_pair : store) {
+        auto &a = *index_ptr_pair.second;
+        // TODO(joeltio): This requires knowledge on how CompVec creates IDs.
+        // Add
+        // TODO(joeltio): iter functionality for compVec
+        for (auto i = 1; i <= a.size(); ++i) {
+            set.emplace(index_ptr_pair.first, i);
         }
-
-        return set;
     }
+
+    return set;
 }
+}  // namespace ics

--- a/sim/lib/core/src/ics/componentStore.test.cpp
+++ b/sim/lib/core/src/ics/componentStore.test.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-#include <core/ics/component.h>
 #include <core/ics/compVec.h>
+#include <core/ics/component.h>
 #include <core/ics/componentStore.h>
+#include <gtest/gtest.h>
 
 #define TEST_SUITE ComponentStoreTest
 
@@ -22,7 +22,7 @@ TEST(TEST_SUITE, CreateVec) {
 TEST(TEST_SUITE, CreateCompVecReturnsReference) {
     ComponentStore store;
     auto& vec = createCompVec<TestComponent>(store, 1);
-    vec.add(TestComponent { true, 20 });
+    vec.add(TestComponent{true, 20});
 
     auto retrievedVec = std::any_cast<CompVec<BaseComponent>>(*store.at(1));
     ASSERT_EQ(retrievedVec.size(), 1);
@@ -31,7 +31,7 @@ TEST(TEST_SUITE, CreateCompVecReturnsReference) {
 TEST(TEST_SUITE, GetComponentsRetrievesComponents) {
     ComponentStore store;
     auto& vec = createCompVec<TestComponent>(store, 1);
-    auto compId = vec.add(TestComponent { true, 20 });
+    auto compId = vec.add(TestComponent{true, 20});
 
     auto retrievedVec = getCompVec<TestComponent>(store, 1);
     ASSERT_EQ(retrievedVec.at(compId).height, 20);
@@ -42,7 +42,7 @@ TEST(TEST_SUITE, GetComponentsRetrievesComponentsByReference) {
     createCompVec<TestComponent>(store, 1);
 
     auto& vec1 = getCompVec<TestComponent>(store, 1);
-    vec1.add(TestComponent { true, 20 });
+    vec1.add(TestComponent{true, 20});
     auto& vec2 = getCompVec<TestComponent>(store, 1);
     ASSERT_EQ(vec2.size(), 1);
 }
@@ -50,7 +50,7 @@ TEST(TEST_SUITE, GetComponentsRetrievesComponentsByReference) {
 TEST(TEST_SUITE, AddComponentsCreatesNewVec) {
     ComponentStore store;
     ASSERT_EQ(store.size(), 0);
-    addComponent(store, TestComponent { true, 20 }, 1);
+    addComponent(store, TestComponent{true, 20}, 1);
     ASSERT_EQ(store.size(), 1);
 }
 
@@ -61,7 +61,7 @@ TEST(TEST_SUITE, AddComponentsAppendsToVec) {
     ASSERT_EQ(getCompVec<TestComponent>(store, 1).size(), 0);
 
     // Ensure that no new vectors are created
-    auto compFullId = addComponent(store, TestComponent { true, 20 }, 1);
+    auto compFullId = addComponent(store, TestComponent{true, 20}, 1);
     ASSERT_EQ(store.size(), 1);
 
     // Ensure that the item is actually appended
@@ -74,12 +74,12 @@ TEST(TEST_SUITE, AsCompSet) {
     ComponentStore store;
     ASSERT_EQ(asCompSet(store).size(), 0);
 
-    addComponent(store, TestComponent { true, 20 }, 1);
-    addComponent(store, TestComponent { true, 20 }, 1);
-    addComponent(store, TestComponent { true, 20 }, 1);
-    addComponent(store, TestComponent { true, 20 }, 1);
-    addComponent(store, TestComponent { true, 20 }, 2);
-    addComponent(store, TestComponent { true, 20 }, 2);
+    addComponent(store, TestComponent{true, 20}, 1);
+    addComponent(store, TestComponent{true, 20}, 1);
+    addComponent(store, TestComponent{true, 20}, 1);
+    addComponent(store, TestComponent{true, 20}, 1);
+    addComponent(store, TestComponent{true, 20}, 2);
+    addComponent(store, TestComponent{true, 20}, 2);
 
     int group1Count = 0;
     int group2Count = 0;
@@ -97,7 +97,7 @@ TEST(TEST_SUITE, AsCompSet) {
 
 TEST(TEST_SUITE, GetComponentByReference) {
     ComponentStore store;
-    auto compId = addComponent(store, TestComponent { true, 20 }, 1);
+    auto compId = addComponent(store, TestComponent{true, 20}, 1);
     ics::Component auto& comp = getComponent<TestComponent>(store, compId);
 
     ASSERT_EQ(comp.height, 20);

--- a/sim/lib/core/src/ics/util/composable.test.cpp
+++ b/sim/lib/core/src/ics/util/composable.test.cpp
@@ -1,40 +1,29 @@
-#include <gtest/gtest.h>
-#include <string>
 #include <core/ics/util/composable.h>
+#include <gtest/gtest.h>
+
+#include <string>
 
 #define TEST_SUITE ComposableTest
 
 using namespace util;
 
-char f(int x) {
-    return 'y';
-}
+char f(int x) { return 'y'; }
 
-bool g(char x) {
-    return false;
-}
+bool g(char x) { return false; }
 
-std::string h(bool x) {
-    return "hello";
-}
+std::string h(bool x) { return "hello"; }
 
 TEST(TEST_SUITE, ComposesFunctions) {
-    auto val = Composable(3000)
-            | &f
-            | &g
-            | &h;
+    auto val = Composable(3000) | &f | &g | &h;
     ASSERT_EQ(val.data, "hello");
 }
 
 typedef std::unordered_map<size_t, std::unique_ptr<int>> Store;
-Store& j(Store& store) {
-    return store;
-}
+Store& j(Store& store) { return store; }
 
 TEST(TEST_SUITE, ComposeByReference) {
     Store store;
     store.emplace(1, std::make_unique<int>(10));
-    auto val = Composable<Store&>(store)
-        | &j;
+    auto val = Composable<Store&>(store) | &j;
     ASSERT_EQ(*val.data.at(1), 10);
 }

--- a/sim/lib/core/src/ics/util/typeMap.test.cpp
+++ b/sim/lib/core/src/ics/util/typeMap.test.cpp
@@ -1,5 +1,6 @@
-#include "gtest/gtest.h"
 #include <core/ics/util/typeMap.h>
+
+#include "gtest/gtest.h"
 
 #define TEST_SUITE TypeMapTest
 
@@ -12,7 +13,7 @@ struct TestStruct {
 
 TEST(TEST_SUITE, InsertAndRetrieveFromTypeMap) {
     auto map = TypeMap();
-    auto d = TestStruct { 1 };
+    auto d = TestStruct{1};
 
     map.insert(d);
 
@@ -21,24 +22,21 @@ TEST(TEST_SUITE, InsertAndRetrieveFromTypeMap) {
 
 TEST(TEST_SUITE, RetrieveNonExistent) {
     auto map = TypeMap();
-    EXPECT_THROW(
-        map.at<TestStruct>(),
-        std::out_of_range
-    );
+    EXPECT_THROW(map.at<TestStruct>(), std::out_of_range);
 }
 
 TEST(TEST_SUITE, CheckExistence) {
     auto map = TypeMap();
     EXPECT_FALSE(map.has<TestStruct>());
 
-    auto d = TestStruct { 1 };
+    auto d = TestStruct{1};
     map.insert(d);
     EXPECT_TRUE(map.has<TestStruct>());
 }
 
 TEST(TEST_SUITE, RetreiveByReference) {
     auto map = TypeMap();
-    map.insert(TestStruct { 3 });
+    map.insert(TestStruct{3});
 
     auto& val = map.at<TestStruct>();
     val.x = 5;

--- a/sim/lib/core/src/systemContext.test.cpp
+++ b/sim/lib/core/src/systemContext.test.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <core/systemContext.h>
+#include <gtest/gtest.h>
 
 #define TEST_SUITE Component
 

--- a/sim/lib/core/src/windowContext.cpp
+++ b/sim/lib/core/src/windowContext.cpp
@@ -1,14 +1,14 @@
 #include <core/windowContext.h>
 
 namespace {
-    void framebufferSizeCallback([[maybe_unused]] GLFWwindow* window, int width, int height) {
-        glViewport(0, 0, width, height);
-    }
+void framebufferSizeCallback([[maybe_unused]] GLFWwindow *window, int width,
+                             int height) {
+    glViewport(0, 0, width, height);
 }
+}  // namespace
 
-WindowContext::WindowContext(
-    int width, int height, const char *title
-) : width(width), height(height), title(title) {
+WindowContext::WindowContext(int width, int height, const char *title)
+    : width(width), height(height), title(title) {
     // Initialise GLFW
     glfwInit();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
@@ -28,28 +28,20 @@ WindowContext::WindowContext(
     glfwSetFramebufferSizeCallback(window, framebufferSizeCallback);
 }
 
-WindowContext::~WindowContext() {
-    glfwTerminate();
-}
+WindowContext::~WindowContext() { glfwTerminate(); }
 
-WindowContext::WindowContext(
-    const WindowContext &other
-) : width(other.width), height(other.height), title(other.title) {
+WindowContext::WindowContext(const WindowContext &other)
+    : width(other.width), height(other.height), title(other.title) {
     // Create a new window with the same parameters
-    window = glfwCreateWindow(
-        other.width,
-        other.height,
-        other.title,
-        nullptr,
-        nullptr
-    );
+    window = glfwCreateWindow(other.width, other.height, other.title, nullptr,
+                              nullptr);
     if (window == nullptr) {
         // TODO(joeltio): Create an exception for this
         throw "Failed to create GLFW window";
     }
 }
 
-WindowContext& WindowContext::operator=(const WindowContext &other) = default;
+WindowContext &WindowContext::operator=(const WindowContext &other) = default;
 
 bool WindowContext::isCurrentContext() const {
     return glfwGetCurrentContext() == window;
@@ -63,12 +55,11 @@ bool WindowContext::shouldClose() const {
     return glfwWindowShouldClose(window);
 }
 
-void WindowContext::updateEvents() { // NOLINT(readability-convert-member-functions-to-static)
+void WindowContext::
+    updateEvents() {  // NOLINT(readability-convert-member-functions-to-static)
     // This function is not made static to cater to other implementations which
     // may require the window variable
     glfwPollEvents();
 }
 
-void WindowContext::swapBuffers() const {
-    glfwSwapBuffers(window);
-}
+void WindowContext::swapBuffers() const { glfwSwapBuffers(window); }

--- a/sim/src/index/componentType.test.cpp
+++ b/sim/src/index/componentType.test.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
 #include <core/ics/component.h>
 #include <core/ics/componentSet.h>
+#include <gtest/gtest.h>
 #include <index/componentType.h>
 
 #define TEST_SUITE ComponentType
@@ -40,8 +40,8 @@ TEST(TEST_SUITE, UseComponentTypeIsFilter) {
     compSet.emplace(group, 2);
     compSet.emplace(group, 5);
     compSet.emplace(group, 13);
-    compSet.emplace(group+1, 3);
-    compSet.emplace(group+1, 7);
+    compSet.emplace(group + 1, 3);
+    compSet.emplace(group + 1, 7);
 
     auto filteredSet = filter(compSet);
     int cumProd = 1;

--- a/sim/src/main.cpp
+++ b/sim/src/main.cpp
@@ -1,9 +1,9 @@
+#include <component/textureComponent.h>
+#include <core/graphicsContext.h>
 #include <core/systemContext.h>
 #include <core/windowContext.h>
-#include <core/graphicsContext.h>
-#include <component/textureComponent.h>
-#include <system/render.h>
 #include <ics.h>
+#include <system/render.h>
 
 int main() {
     WindowContext windowContext = WindowContext(800, 600, "Bento Box");
@@ -24,8 +24,7 @@ int main() {
     const SystemFn<ics::index::IndexStore> a(&ics::system::render);
     systemContext.systems.push_front(a);
 
-    while(!windowContext.shouldClose())
-    {
+    while (!windowContext.shouldClose()) {
         glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
 

--- a/sim/src/main.test.cpp
+++ b/sim/src/main.test.cpp
@@ -1,6 +1,8 @@
-#include <string>
-#include <gtest/gtest.h>
 #include <google/protobuf/util/message_differencer.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
 #include "bento/protos/references.pb.h"
 
 using namespace std;

--- a/sim/src/system/render.cpp
+++ b/sim/src/system/render.cpp
@@ -1,21 +1,24 @@
-#include <system/render.h>
-#include <iostream>
-
 #include <component/textureComponent.h>
 #include <core/ics/componentStore.h>
 #include <core/ics/util/composable.h>
+#include <system/render.h>
+
+#include <iostream>
 
 namespace ics::system {
-    void render(GraphicsContext &graphicsContext, ics::ComponentStore &componentStore, ics::index::IndexStore &indexStore) {
-        auto& componentType = indexStore.componentType;
-        auto components = util::Composable<ComponentStore&>(componentStore)
-            | ics::asCompSet
-            | componentType.is<ics::component::Texture2DComponent>();
+void render(GraphicsContext &graphicsContext,
+            ics::ComponentStore &componentStore,
+            ics::index::IndexStore &indexStore) {
+    auto &componentType = indexStore.componentType;
+    auto components = util::Composable<ComponentStore &>(componentStore) |
+                      ics::asCompSet |
+                      componentType.is<ics::component::Texture2DComponent>();
 
-        for (auto componentId : components.data) {
-            auto component = ics::getComponent<ics::component::Texture2DComponent>(componentStore, componentId);
-            // TODO(joeltio): Use the graphics context to render the texture
-            std::cout << "texture: " << component.texture << std::endl;
-        }
+    for (auto componentId : components.data) {
+        auto component = ics::getComponent<ics::component::Texture2DComponent>(
+            componentStore, componentId);
+        // TODO(joeltio): Use the graphics context to render the texture
+        std::cout << "texture: " << component.texture << std::endl;
     }
 }
+}  // namespace ics::system


### PR DESCRIPTION
Add clang-format to Lint and Format bentobox-sim and Protobuf Definitions:
- Use `clang-format` to auto format  bentobox-sim c++ source code with google-code style with 4 space indent.
- Use `clang-format` to auto format  bentobox-sim Protobuf definitions  with google-code style.
- Add lint checks to check that code has been formatted properly with `clang-format`.
- Apply `clang-format` to existing code.