### PR TITLE
chore(e2e): Implement E2E tests for Get/Set Attribute & Stepping Simulations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,4 +139,4 @@ jobs:
           make lint-e2e
       - name: "Run End to End Tests"
         run: |
-          make test-e2e
+          make test-e2e-docker

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -3,10 +3,11 @@
 # E2E Test
 #
 # Requires environment variables to be specified:
-# - BENTOBOX_SIM_DOCKER - tag of the bentobox-sim docker image to run
+# - ENGINE_DOCKER - tag of the bentobox-sim docker image to run
 
 import os
 import pytest
+from distutils.util import strtobool
 from git import Repo
 from math import cos, sin
 from testcontainers.core.container import DockerContainer
@@ -19,7 +20,13 @@ from bento.graph.plotter import Plotter
 from bento.ecs.spec import EntityDef, ComponentDef
 from bento.example.specs import Velocity, Position
 
-SIM_PORT = 54242
+# port that the engine listens on
+ENGINE_PORT = 54242
+# whether to start a docker container to provide the engine component in the e2e test
+# if False, an engine instance should be already listening at locahost:ENGINE_PORT
+# Requires environment variables to be specified:
+# - ENGINE_CONTAINER - tag of the bentobox-sim docker image to run
+BOOT_ENGINE_CONTAINER = strtobool(os.environ.get("BOOT_ENGINE_CONTAINER", default=True))
 
 # define test components
 Meta = ComponentDef(
@@ -50,32 +57,39 @@ Keyboard = ComponentDef(
 
 
 @pytest.fixture
-def engine_docker():
-    # since this fixture as function scope, a fresh Engine instance
-    # would be created for each e2e test.
-    # setup bentobox-sim container and expose engine port
-    engine = DockerContainer(os.environ["BENTOBOX_SIM_DOCKER"])
-    engine.with_env("BENTOBOX_SIM_PORT", str(SIM_PORT))
-    engine.with_env("BENTOBOX_SIM_HOST", "0.0.0.0")
-    engine.with_exposed_ports(SIM_PORT)
-    engine.start()
-    # do e2e test
-    yield engine
-    # print the engine's logs
-    print("=" * 40, "[Engine Logs]", "=" * 40)
-    print(engine._container.logs().decode())
-    # cleanup by stopping sim container at end of test
-    # kill the container instead of waiting for cleanup
-    engine.stop(force=True)
+def engine_address():
+    print(BOOT_ENGINE_CONTAINER)
+    if BOOT_ENGINE_CONTAINER:
+        print("e2e: Using Engine Container to provide Engine for E2E")
+        # since this fixture as function scope, a fresh Engine instance
+        # would be created for each e2e test
+        # setup bentobox-sim container and expose engine port
+        engine = DockerContainer(os.environ["ENGINE_CONTAINER"])
+        engine.with_env("ENGINE_PORT", str(ENGINE_PORT))
+        engine.with_env("ENGINE_HOST", "0.0.0.0")
+        engine.with_exposed_ports(ENGINE_PORT)
+        engine.start()
+        # do e2e test
+        yield engine.get_container_host_ip(), engine.get_exposed_port(ENGINE_PORT)
+        # print the engine's logs
+        print("=" * 40, "[Engine Logs]", "=" * 40)
+        print(engine._container.logs().decode())
+        print("=" * 40, "[Engine Logs]", "=" * 40)
+        # cleanup by stopping sim container at end of test
+        # kill the container instead of waiting for cleanup
+        engine.stop(force=True)
+    else:
+        print(f"e2e: Using Engine instance listening on localhost:{ENGINE_PORT}")
+        print(f"e2e: Warning: Engine instance not reset for each E2E test")
+        # perform e2e test on already started engine instance listening on localhost
+        yield "localhost", ENGINE_PORT
 
 
 @pytest.fixture
-def client(engine_docker):
+def client(engine_address):
     # setup bentobox-sdk client
-    client = Client(
-        host=engine_docker.get_container_host_ip(),
-        port=engine_docker.get_exposed_port(SIM_PORT),
-    )
+    engine_host, engine_port = engine_address
+    client = Client(host=engine_host, port=engine_port)
     # wait for sim to start accepting connections from the SDK
     client.connect(timeout_sec=30)
     return client

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -19,7 +19,7 @@ from bento.graph.plotter import Plotter
 from bento.ecs.spec import EntityDef, ComponentDef
 from bento.example.specs import Velocity, Position
 
-SIM_PORT = 54243
+SIM_PORT = 54242
 
 # define test components
 Meta = ComponentDef(

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -26,7 +26,9 @@ ENGINE_PORT = 54242
 # if False, an engine instance should be already listening at locahost:ENGINE_PORT
 # Requires environment variables to be specified:
 # - ENGINE_CONTAINER - tag of the bentobox-sim docker image to run
-BOOT_ENGINE_CONTAINER = strtobool(os.environ.get("BOOT_ENGINE_CONTAINER", default=True))
+BOOT_ENGINE_CONTAINER = strtobool(
+    os.environ.get("BOOT_ENGINE_CONTAINER", default="True")
+)
 
 # define test components
 Meta = ComponentDef(
@@ -65,8 +67,8 @@ def engine_address():
         # would be created for each e2e test
         # setup bentobox-sim container and expose engine port
         engine = DockerContainer(os.environ["ENGINE_CONTAINER"])
-        engine.with_env("ENGINE_PORT", str(ENGINE_PORT))
-        engine.with_env("ENGINE_HOST", "0.0.0.0")
+        engine.with_env("BENTOBOX_SIM_PORT", str(ENGINE_PORT))
+        engine.with_env("BENTOBOX_SIM_HOST", "0.0.0.0")
         engine.with_exposed_ports(ENGINE_PORT)
         engine.start()
         # do e2e test

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -37,14 +37,14 @@ Meta = ComponentDef(
     name="meta",
     schema={
         "name": types.string,
-        "id": types.int64,
+        "id": types.int32,
         "version": types.int32,
     },
 )
 Movement = ComponentDef(
     name="movement",
     schema={
-        "rotation": types.float32,
+        "rotation": types.float64,
         "speed": types.float64,
     },
 )
@@ -56,7 +56,6 @@ Keyboard = ComponentDef(
         "down": types.boolean,
         "left": types.boolean,
         "right": types.boolean,
-        "key": types.byte,
     },
 )
 
@@ -120,7 +119,6 @@ def sim(client):
         controls[Keyboard].right = False
         controls[Keyboard].up = False
         controls[Keyboard].down = False
-        controls[Keyboard].key = 0
 
         car = g.entity(components=[Movement, Velocity, Position, Meta])
         car[Meta].name = "beetle"
@@ -154,10 +152,6 @@ def sim(client):
         elif controls[Keyboard].down:
             car[Movement].speed = g.max(car[Movement].speed - acceleration, 0.0)
             controls[Keyboard].down = False
-        elif controls[Keyboard].key == ord(" "):
-            # handbrake on space: slow down twice as fast
-            car[Movement].speed = g.max(car[Movement].speed - 2 * acceleration, 0.0)
-            controls[Keyboard].key = 0
 
     @sim.system
     def physics_sys(g: Plotter):
@@ -241,16 +235,16 @@ def test_e2e_engine_implict_type_convert(sim, client):
     # setup test values to attributes
     car[Meta].id = 1
     car[Meta].version = 1
-    car[Meta].speed = 1.0
-    car[Meta].rotation = 1.0
+    car[Movement].speed = 1.0
+    car[Movement].rotation = 1.0
 
     # test implicit type conversion with combinations of numeric data types
     # numeric data type => lambda to , get attribute) with that data type
     dtype_attrs = {
-        types.int64: (lambda: car[Meta].id),
-        types.int32: (lambda: car[Meta].version),
-        types.float64: (lambda: car[Movement].speed),
-        types.float32: (lambda: car[Movement].rotation),
+        "types.int64": (lambda: car[Meta].id),
+        "types.int32": (lambda: car[Meta].version),
+        "types.float64": (lambda: car[Movement].speed),
+        "types.float32": (lambda: car[Movement].rotation),
     }
 
     for dtype in dtype_attrs.keys():
@@ -262,9 +256,9 @@ def test_e2e_engine_implict_type_convert(sim, client):
             elif dtype == types.int32:
                 car[Meta].version = value_attr()
             elif dtype == types.float64:
-                car[Meta].speed = value_attr()
+                car[Movement].speed = value_attr()
             elif dtype == types.float32:
-                car[Meta].rotation = value_attr()
+                car[Movement].rotation = value_attr()
 
             actual_attr = dtype_attrs[dtype]
             assert actual_attr() == 1
@@ -280,7 +274,6 @@ def test_e2e_engine_step_sim(sim, client):
     assert controls[Keyboard].right == False
     assert controls[Keyboard].up == False
     assert controls[Keyboard].left == False
-    assert controls[Keyboard].key == 0
 
     car = sim.entity(components=[Movement, Velocity, Position, Meta])
     assert car[Meta].name == "beetle"

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -246,7 +246,7 @@ def test_e2e_engine_implict_type_convert(sim, client):
     }
 
     for dtype in dtype_attrs.keys():
-        other_dtypes = [ t for t in dtype_attrs.keys() if t != dtype ]
+        other_dtypes = [t for t in dtype_attrs.keys() if t != dtype]
         for other_dtype in other_dtypes:
             value_attr = dtype_attrs[other_dtype]
             if dtype == types.int64:
@@ -260,6 +260,7 @@ def test_e2e_engine_implict_type_convert(sim, client):
 
             actual_attr = dtype_attrs[dtype]
             assert actual_attr() == 1
+
 
 def test_e2e_engine_step_sim(sim, client):
     # once https://github.com/joeltio/bento-box/issues/34 is fixed.

--- a/e2e/test_e2e.py
+++ b/e2e/test_e2e.py
@@ -1,5 +1,3 @@
-# type: ignore
-# TODO(mrzzy): remove this before commit
 #
 # bento-box
 # E2E Test

--- a/makefile
+++ b/makefile
@@ -97,8 +97,8 @@ test-sim: build-sim
 	$(SIM_BUILD_DIR)/$(SIM_TEST)
 
 run-sim: build-sim
-	env BENTOBOX_SIM_PORT=$(SIM_PORT)\
-		BENTOBOX_SIM_HOST=$(SIM_HOST)
+	env ENGINE_PORT=$(SIM_PORT)\
+		ENGINE_HOST=$(SIM_HOST)
 		$(SIM_BUILD_DIR)/$(SIM_TARGET)
 
 debug-sim: build-sim
@@ -178,7 +178,11 @@ lint-e2e: dep-e2e
 
 test-e2e-docker: dep-e2e install-sdk build-sim-docker
 	cd $(E2E_TESTS) && \
-		env BENTOBOX_SIM_DOCKER=$(SIM_DOCKER) $(PYTEST)
+		env ENGINE_CONTAINER=$(SIM_DOCKER) BOOT_ENGINE_CONTAINER=True $(PYTEST)
+
+test-e2e: dep-e2e install-sdk build-sim
+	cd $(E2E_TESTS) && \
+		env BOOT_ENGINE_CONTAINER=False $(PYTEST)
 
 # spellcheck bentobox codebase
 .PHONY: spellcheck autocorrect

--- a/makefile
+++ b/makefile
@@ -17,7 +17,7 @@ DOCKER:=docker
 .PHONY: deps build test clean test
 build: build-sim build-sdk
 
-test: test-sim test-sdk test-e2e
+test: test-sim test-sdk test-e2e-docker
 
 clean: clean-sim clean-sdk
 
@@ -164,7 +164,7 @@ clean-sdk-docs: $(SDK_DOC_DIR)
 ## End to End tests
 E2E_TESTS:=e2e
 
-.PHONY: dep-e2e format-e2e lint-e2e test-e2e
+.PHONY: dep-e2e format-e2e lint-e2e test-e2e-docker
 
 # dep-e2e adds on to the requirements defined in  SDK's requirements-dev.txt
 dep-e2e: dep-sdk-dev
@@ -176,7 +176,7 @@ format-e2e: dep-e2e
 lint-e2e: dep-e2e
 	$(BLACK_FMT) --check $(E2E_TESTS)
 
-test-e2e: dep-e2e install-sdk build-sim-docker
+test-e2e-docker: dep-e2e install-sdk build-sim-docker
 	cd $(E2E_TESTS) && \
 		env BENTOBOX_SIM_DOCKER=$(SIM_DOCKER) $(PYTEST)
 

--- a/sdk/bento/types.py
+++ b/sdk/bento/types.py
@@ -6,7 +6,7 @@
 from bento.protos.types_pb2 import Type
 
 # Provide easier access to Proto types
-char = Type(primitive=Type.Primitive.BYTE)
+byte = Type(primitive=Type.Primitive.BYTE)
 int32 = Type(primitive=Type.Primitive.INT32)
 int64 = Type(primitive=Type.Primitive.INT64)
 float32 = Type(primitive=Type.Primitive.FLOAT32)


### PR DESCRIPTION
Partially Implements: #36 

Adds E2E Tests for:
-  Stepping a Simulation to run for a step and checking for expected changes based on systems.
-  Getting/Setting component attributes.
-  Implicit data types conversion between `int32`, `int64`, `float32`, `float64` numeric data types.

> Scope: Not all data types are tested due to #54 

Improve Project Makefile when running E2E tests:
- Rename `test-e2e` target in project makefile to `test-e2e-docker` to be more specific.
- Add `test-e2e` to run E2E tests on a local  Engine instance.

SDK: Rename test-e2e target in project makefile to test-e2e-docker to be more specific