### PR TITLE
Engine: Allow implicit type conversion for mutateOp, add existence check before retrieving component value

### DIFF
--- a/sim/include/proto/userValue.h
+++ b/sim/include/proto/userValue.h
@@ -76,15 +76,15 @@ requires(proto::ProtobufType<Ts>&&...) bool isValOfTypes(
 }
 
 template <class T>
-requires ProtobufType<T> bool isTypeOfType(
+requires ProtobufType<T> bool isProtoTypeOfType(
     const bento::protos::Type& protoType) {
     throw std::runtime_error("Invalid protobuf type.");
 }
 
 template <class... Ts>
-requires(proto::ProtobufType<Ts>&&...) bool isTypeOfTypes(
+requires(proto::ProtobufType<Ts>&&...) bool isProtoTypeOfTypes(
     const bento::protos::Type& protoType) {
-    return (proto::isTypeOfType<Ts>(protoType) || ...);
+    return (proto::isProtoTypeOfType<Ts>(protoType) || ...);
 }
 
 // Validates if a given type is in a list of types
@@ -114,7 +114,7 @@ void runFnWithValType(const bento::protos::Type& type, Fn fn) {
 
     bool fnCalled = false;
     if constexpr (typeInTypes<INT32, AllowedTypes...>) {
-        if (isTypeOfType<INT32>(type)) {
+        if (isProtoTypeOfType<INT32>(type)) {
             // Calling the lambda with a template parameter is not possible, so
             // we make use of type deduction here to provide the type. We do so
             // by using a pointer casted to the right type.
@@ -123,31 +123,31 @@ void runFnWithValType(const bento::protos::Type& type, Fn fn) {
         }
     }
     if constexpr (typeInTypes<INT64, AllowedTypes...>) {
-        if (isTypeOfType<INT64>(type)) {
+        if (isProtoTypeOfType<INT64>(type)) {
             fn((INT64*)nullptr);
             fnCalled = true;
         }
     }
     if constexpr (typeInTypes<FLOAT32, AllowedTypes...>) {
-        if (isTypeOfType<FLOAT32>(type)) {
+        if (isProtoTypeOfType<FLOAT32>(type)) {
             fn((FLOAT32*)nullptr);
             fnCalled = true;
         }
     }
     if constexpr (typeInTypes<FLOAT64, AllowedTypes...>) {
-        if (isTypeOfType<FLOAT64>(type)) {
+        if (isProtoTypeOfType<FLOAT64>(type)) {
             fn((FLOAT64*)nullptr);
             fnCalled = true;
         }
     }
     if constexpr (typeInTypes<STR, AllowedTypes...>) {
-        if (isTypeOfType<STR>(type)) {
+        if (isProtoTypeOfType<STR>(type)) {
             fn((STR*)nullptr);
             fnCalled = true;
         }
     }
     if constexpr (typeInTypes<BOOL, AllowedTypes...>) {
-        if (isTypeOfType<BOOL>(type)) {
+        if (isProtoTypeOfType<BOOL>(type)) {
             fn((BOOL*)nullptr);
             fnCalled = true;
         }

--- a/sim/include/proto/userValue.h
+++ b/sim/include/proto/userValue.h
@@ -96,6 +96,13 @@ template <class Type, class... TypeList>
 constexpr bool typeInTypes =
     std::disjunction_v<std::is_same<Type, TypeList>...>;
 
+// Runs a function with a pointer casted to the deduced type
+// For example, if `type` is an INT64, then, the lambda function will be called
+// as:
+// fn((INT64*)nullptr);
+// The type signature for the lambda is:
+// []<class X>(X* _) {};
+// In this way, the lambda can deduce the type based on the pointer provided.
 template <class... AllowedTypes, class Fn>
 void runFnWithValType(const bento::protos::Type& type, Fn fn) {
     if (type.has_array()) {
@@ -106,9 +113,11 @@ void runFnWithValType(const bento::protos::Type& type, Fn fn) {
     }
 
     bool fnCalled = false;
-    auto primitiveType = type.primitive();
     if constexpr (typeInTypes<INT32, AllowedTypes...>) {
         if (isTypeOfType<INT32>(type)) {
+            // Calling the lambda with a template parameter is not possible, so
+            // we make use of type deduction here to provide the type. We do so
+            // by using a pointer casted to the right type.
             fn((INT32*)nullptr);
             fnCalled = true;
         }

--- a/sim/include/proto/userValue.h
+++ b/sim/include/proto/userValue.h
@@ -81,8 +81,8 @@ requires ProtobufType<T> bool isTypeOfType(
     throw std::runtime_error("Invalid protobuf type.");
 }
 
-template <class ...Ts>
-requires (proto::ProtobufType<Ts>&&...) bool isTypeOfTypes(
+template <class... Ts>
+requires(proto::ProtobufType<Ts>&&...) bool isTypeOfTypes(
     const bento::protos::Type& protoType) {
     return (proto::isTypeOfType<Ts>(protoType) || ...);
 }

--- a/sim/src/component/userComponent.cpp
+++ b/sim/src/component/userComponent.cpp
@@ -51,7 +51,7 @@ void UserComponent::setValue(const std::string& attrName,
 
     // TODO(joeltio): Streamline this together with eqOp
     // If schemaType and value are numeric, try to convert
-    if (proto::isTypeOfTypes<proto_NUMERIC>(schemaType) &&
+    if (proto::isProtoTypeOfTypes<proto_NUMERIC>(schemaType) &&
         proto::isValOfTypes<proto_NUMERIC>(value)) {
         proto::runFnWithVal<proto_NUMERIC>(
             value, [&valToSet, &schemaType]<class X>(X x) {

--- a/sim/src/component/userComponent.cpp
+++ b/sim/src/component/userComponent.cpp
@@ -1,6 +1,7 @@
 #include <component/userComponent.h>
 #include <google/protobuf/util/message_differencer.h>
 #include <proto/valueType.h>
+#include <proto/userValue.h>
 
 namespace ics::component {
 
@@ -25,17 +26,54 @@ void UserComponent::setValue(const std::string& attrName,
             "Missing data type when setting value for attribute " + attrName);
     }
 
-    auto schemaType = compDef.schema().at(attrName);
-    auto differencer = google::protobuf::util::MessageDifferencer();
-    if (!differencer.Compare(schemaType, value.data_type())) {
+    // Ensure that data_type and value match
+    if (!proto::valHasCorrectDataType(value)) {
         throw std::runtime_error(
-            "Data type of given value does not match schema type for "
+            "Data stored in value and data type stored in value do not match. "
+            "Data stored type: " +
+            proto::valStoredTypeName(value) +
+            ", data type: " + proto::valDataTypeName(value.data_type()));
+    }
+
+    auto& valToSet = values[attrName];
+    auto& schemaType = compDef.schema().at(attrName);
+    if (schemaType.has_array()) {
+        // Just set the array value completely
+        valToSet = value;
+        return;
+    }
+
+    // TODO(joeltio): Streamline this together with eqOp
+    // If schemaType and value are numeric, try to convert
+    if (proto::isTypeOfTypes<proto_NUMERIC>(schemaType) &&
+        proto::isValOfTypes<proto_NUMERIC>(value)) {
+        proto::runFnWithVal<proto_NUMERIC>(
+            value, [&valToSet, &schemaType]<class X>(X x) {
+                proto::runFnWithValType<proto_NUMERIC>(
+                    schemaType, [&valToSet, &x]<class Y>(Y* _) {
+                        proto::setVal(valToSet, (Y)x);
+                    });
+
+                // Return something random since it is required
+                return 3;
+            });
+        return;
+    }
+
+    // Otherwise, require that the value's data_type is the same as the
+    // schemaType
+    auto differencer = google::protobuf::util::MessageDifferencer();
+    // Ensure that the data_types between schema and value match
+    if (!differencer.Compare(value.data_type(), schemaType)) {
+        throw std::runtime_error(
+            "Data type of given value does not match component's schemaType "
+            "for "
             "attribute " +
             attrName + ". Expected: " + proto::valDataTypeName(schemaType) +
             ", Got: " + proto::valDataTypeName(value.data_type()) + ".");
     }
 
-    values[attrName] = value;
+    valToSet = value;
 }
 
 }  // namespace ics::component

--- a/sim/src/component/userComponent.cpp
+++ b/sim/src/component/userComponent.cpp
@@ -12,7 +12,13 @@ const bento::protos::Value& UserComponent::getValue(
 
 bento::protos::Value& UserComponent::getMutableValue(
     const std::string& attrName) {
-    return values[attrName];
+    auto& val = values[attrName];
+    if (!val.has_primitive() && !val.has_array()) {
+        throw std::runtime_error(
+            "Attempting to retrieve primitive value which has not been set");
+    }
+
+    return val;
 }
 
 void UserComponent::setValue(const std::string& attrName,

--- a/sim/src/component/userComponent.test.cpp
+++ b/sim/src/component/userComponent.test.cpp
@@ -93,3 +93,8 @@ TEST(TEST_SUITE, SetValueImplicitCast) {
     comp.setValue("height", height);
     ASSERT_EQ(comp.getValue("height").primitive().int_64(), 20);
 }
+
+TEST(TEST_SUITE, GetValueWhichHasNotBeenSet) {
+    TestComponent comp;
+    ASSERT_ANY_THROW(comp.getValue("height"));
+}

--- a/sim/src/interpreter/operations.cpp
+++ b/sim/src/interpreter/operations.cpp
@@ -33,7 +33,6 @@ void mutateOp(ics::ComponentStore& compStore,
     auto& ref = node.mutate_attr();
     auto& component = ics::getComponent(indexStore, compStore, ref.component(),
                                         ref.entity_id());
-    auto& mutableVal = component.getMutableValue(ref.attribute());
 
     // Set the value
     component.setValue(ref.attribute(), val);

--- a/sim/src/proto/userValue.cpp
+++ b/sim/src/proto/userValue.cpp
@@ -111,32 +111,32 @@ bool isValOfType<BOOL>(const bento::protos::Value& protoVal) {
 }
 
 template <>
-bool isTypeOfType<INT32>(const bento::protos::Type& protoType) {
+bool isProtoTypeOfType<INT32>(const bento::protos::Type& protoType) {
     return protoType.primitive() == bento::protos::Type_Primitive_INT32;
 }
 
 template <>
-bool isTypeOfType<INT64>(const bento::protos::Type& protoType) {
+bool isProtoTypeOfType<INT64>(const bento::protos::Type& protoType) {
     return protoType.primitive() == bento::protos::Type_Primitive_INT64;
 }
 
 template <>
-bool isTypeOfType<FLOAT32>(const bento::protos::Type& protoType) {
+bool isProtoTypeOfType<FLOAT32>(const bento::protos::Type& protoType) {
     return protoType.primitive() == bento::protos::Type_Primitive_FLOAT32;
 }
 
 template <>
-bool isTypeOfType<FLOAT64>(const bento::protos::Type& protoType) {
+bool isProtoTypeOfType<FLOAT64>(const bento::protos::Type& protoType) {
     return protoType.primitive() == bento::protos::Type_Primitive_FLOAT64;
 }
 
 template <>
-bool isTypeOfType<STR>(const bento::protos::Type& protoType) {
+bool isProtoTypeOfType<STR>(const bento::protos::Type& protoType) {
     return protoType.primitive() == bento::protos::Type_Primitive_STRING;
 }
 
 template <>
-bool isTypeOfType<BOOL>(const bento::protos::Type& protoType) {
+bool isProtoTypeOfType<BOOL>(const bento::protos::Type& protoType) {
     return protoType.primitive() == bento::protos::Type_Primitive_BOOL;
 }
 

--- a/sim/src/proto/userValue.cpp
+++ b/sim/src/proto/userValue.cpp
@@ -110,4 +110,53 @@ bool isValOfType<BOOL>(const bento::protos::Value& protoVal) {
            bento::protos::Value_Primitive::kBoolean;
 }
 
+template <>
+bool isTypeOfType<INT32>(const bento::protos::Type& protoType) {
+    return protoType.primitive() == bento::protos::Type_Primitive_INT32;
+}
+
+template <>
+bool isTypeOfType<INT64>(const bento::protos::Type& protoType) {
+    return protoType.primitive() == bento::protos::Type_Primitive_INT64;
+}
+
+template <>
+bool isTypeOfType<FLOAT32>(const bento::protos::Type& protoType) {
+    return protoType.primitive() == bento::protos::Type_Primitive_FLOAT32;
+}
+
+template <>
+bool isTypeOfType<FLOAT64>(const bento::protos::Type& protoType) {
+    return protoType.primitive() == bento::protos::Type_Primitive_FLOAT64;
+}
+
+template <>
+bool isTypeOfType<STR>(const bento::protos::Type& protoType) {
+    return protoType.primitive() == bento::protos::Type_Primitive_STRING;
+}
+
+template <>
+bool isTypeOfType<BOOL>(const bento::protos::Type& protoType) {
+    return protoType.primitive() == bento::protos::Type_Primitive_BOOL;
+}
+
+bool valHasCorrectDataType(const bento::protos::Value& val) {
+    // Handle unset data_type
+    if (!val.has_data_type()) {
+        return false;
+    }
+
+    bool result;
+    runFnWithValType<proto_ANY>(
+        val.data_type(), [&val, &result]<class X>(X* _) {
+            runFnWithVal<proto_ANY>(val, [&result]<class Y>(Y y) {
+                result = std::is_same_v<X, Y>;
+                // Return something random since it is required
+                return 3;
+            });
+        });
+
+    return result;
+}
+
 }  // namespace proto

--- a/sim/src/proto/userValue.test.cpp
+++ b/sim/src/proto/userValue.test.cpp
@@ -112,48 +112,48 @@ TEST(TEST_SUITE, IsTypeOfType) {
     auto type = bento::protos::Type();
     // Test all the true cases
     type.set_primitive(bento::protos::Type_Primitive_INT32);
-    ASSERT_TRUE(isTypeOfType<INT32>(type));
+    ASSERT_TRUE(isProtoTypeOfType<INT32>(type));
     type.set_primitive(bento::protos::Type_Primitive_INT64);
-    ASSERT_TRUE(isTypeOfType<INT64>(type));
+    ASSERT_TRUE(isProtoTypeOfType<INT64>(type));
 
     type.set_primitive(bento::protos::Type_Primitive_FLOAT32);
-    ASSERT_TRUE(isTypeOfType<FLOAT32>(type));
+    ASSERT_TRUE(isProtoTypeOfType<FLOAT32>(type));
     type.set_primitive(bento::protos::Type_Primitive_FLOAT64);
-    ASSERT_TRUE(isTypeOfType<FLOAT64>(type));
+    ASSERT_TRUE(isProtoTypeOfType<FLOAT64>(type));
 
     type.set_primitive(bento::protos::Type_Primitive_STRING);
-    ASSERT_TRUE(isTypeOfType<STR>(type));
+    ASSERT_TRUE(isProtoTypeOfType<STR>(type));
     type.set_primitive(bento::protos::Type_Primitive_BOOL);
-    ASSERT_TRUE(isTypeOfType<BOOL>(type));
+    ASSERT_TRUE(isProtoTypeOfType<BOOL>(type));
 
     // Test some false cases
-    ASSERT_FALSE(isTypeOfType<INT32>(type));
-    ASSERT_FALSE(isTypeOfType<INT64>(type));
+    ASSERT_FALSE(isProtoTypeOfType<INT32>(type));
+    ASSERT_FALSE(isProtoTypeOfType<INT64>(type));
 
     type.set_primitive(bento::protos::Type_Primitive_FLOAT32);
-    ASSERT_FALSE(isTypeOfType<STR>(type));
-    ASSERT_FALSE(isTypeOfType<FLOAT64>(type));
+    ASSERT_FALSE(isProtoTypeOfType<STR>(type));
+    ASSERT_FALSE(isProtoTypeOfType<FLOAT64>(type));
 
     type.set_primitive(bento::protos::Type_Primitive_INT32);
-    ASSERT_FALSE(isTypeOfType<BOOL>(type));
-    ASSERT_FALSE(isTypeOfType<FLOAT32>(type));
+    ASSERT_FALSE(isProtoTypeOfType<BOOL>(type));
+    ASSERT_FALSE(isProtoTypeOfType<FLOAT32>(type));
 }
 
 TEST(TEST_SUITE, IsTypeOfTypes) {
     auto type = bento::protos::Type();
 
     type.set_primitive(bento::protos::Type_Primitive_INT32);
-    bool isValid = isTypeOfTypes<INT32, FLOAT64>(type);
+    bool isValid = isProtoTypeOfTypes<INT32, FLOAT64>(type);
     // For some reason, putting the literal into the ASSERT_TRUE macro fails to
     // compile
     ASSERT_TRUE(isValid);
-    isValid = isTypeOfTypes<FLOAT64, STR, BOOL>(type);
+    isValid = isProtoTypeOfTypes<FLOAT64, STR, BOOL>(type);
     ASSERT_FALSE(isValid);
 
     type.set_primitive(bento::protos::Type_Primitive_BOOL);
-    isValid = isTypeOfTypes<STR, FLOAT64, BOOL>(type);
+    isValid = isProtoTypeOfTypes<STR, FLOAT64, BOOL>(type);
     ASSERT_TRUE(isValid);
-    isValid = isTypeOfTypes<FLOAT64, STR, INT32>(type);
+    isValid = isProtoTypeOfTypes<FLOAT64, STR, INT32>(type);
     ASSERT_FALSE(isValid);
 }
 

--- a/sim/src/proto/userValue.test.cpp
+++ b/sim/src/proto/userValue.test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <proto/userValue.h>
+#include <bento/protos/types.pb.h>
 
 #include <utility>
 
@@ -107,6 +108,55 @@ TEST(TEST_SUITE, IsValueOfTypes) {
     ASSERT_FALSE(isValid);
 }
 
+TEST(TEST_SUITE, IsTypeOfType) {
+    auto type = bento::protos::Type();
+    // Test all the true cases
+    type.set_primitive(bento::protos::Type_Primitive_INT32);
+    ASSERT_TRUE(isTypeOfType<INT32>(type));
+    type.set_primitive(bento::protos::Type_Primitive_INT64);
+    ASSERT_TRUE(isTypeOfType<INT64>(type));
+
+    type.set_primitive(bento::protos::Type_Primitive_FLOAT32);
+    ASSERT_TRUE(isTypeOfType<FLOAT32>(type));
+    type.set_primitive(bento::protos::Type_Primitive_FLOAT64);
+    ASSERT_TRUE(isTypeOfType<FLOAT64>(type));
+
+    type.set_primitive(bento::protos::Type_Primitive_STRING);
+    ASSERT_TRUE(isTypeOfType<STR>(type));
+    type.set_primitive(bento::protos::Type_Primitive_BOOL);
+    ASSERT_TRUE(isTypeOfType<BOOL>(type));
+
+    // Test some false cases
+    ASSERT_FALSE(isTypeOfType<INT32>(type));
+    ASSERT_FALSE(isTypeOfType<INT64>(type));
+
+    type.set_primitive(bento::protos::Type_Primitive_FLOAT32);
+    ASSERT_FALSE(isTypeOfType<STR>(type));
+    ASSERT_FALSE(isTypeOfType<FLOAT64>(type));
+
+    type.set_primitive(bento::protos::Type_Primitive_INT32);
+    ASSERT_FALSE(isTypeOfType<BOOL>(type));
+    ASSERT_FALSE(isTypeOfType<FLOAT32>(type));
+}
+
+TEST(TEST_SUITE, IsTypeOfTypes) {
+    auto type = bento::protos::Type();
+
+    type.set_primitive(bento::protos::Type_Primitive_INT32);
+    bool isValid = isTypeOfTypes<INT32, FLOAT64>(type);
+    // For some reason, putting the literal into the ASSERT_TRUE macro fails to
+    // compile
+    ASSERT_TRUE(isValid);
+    isValid = isTypeOfTypes<FLOAT64, STR, BOOL>(type);
+    ASSERT_FALSE(isValid);
+
+    type.set_primitive(bento::protos::Type_Primitive_BOOL);
+    isValid = isTypeOfTypes<STR, FLOAT64, BOOL>(type);
+    ASSERT_TRUE(isValid);
+    isValid = isTypeOfTypes<FLOAT64, STR, INT32>(type);
+    ASSERT_FALSE(isValid);
+}
+
 TEST(TEST_SUITE, RunFnWithValRunsFunction) {
     {
         auto val = bento::protos::Value();
@@ -139,6 +189,25 @@ TEST(TEST_SUITE, RunFnWithValDetectsTypes) {
         valFloat, valInt, []<class X, class Y>(X x, Y y) { return x + y; });
     // The addition of float and int is float
     ASSERT_FLOAT_EQ(newVal.primitive().float_32(), 30.0);
+}
+
+TEST(TEST_SUITE, RunFnWithValTypeDetectsTypes) {
+    auto typeFloat = bento::protos::Type();
+    typeFloat.set_primitive(bento::protos::Type_Primitive_FLOAT32);
+
+    auto valid = false;
+    runFnWithValType<FLOAT32, INT32>(typeFloat, [&valid]<class X>(X* _) {
+        valid = std::is_same_v<X, FLOAT32>;
+    });
+    ASSERT_TRUE(valid);
+
+    auto typeInt = bento::protos::Type();
+    typeInt.set_primitive(bento::protos::Type_Primitive_INT32);
+
+    valid = false;
+    runFnWithValType<FLOAT32, INT32>(
+        typeInt, [&valid]<class X>(X* _) { valid = std::is_same_v<X, INT32>; });
+    ASSERT_TRUE(valid);
 }
 
 TEST(TEST_SUITE, ConvertTypeFromLambda) {
@@ -198,4 +267,20 @@ TEST(TEST_SUITE, RetTypeFromAdditionType) {
         ASSERT_EQ(val.primitive().value_case(),
                   bento::protos::Type_Primitive_FLOAT64);
     }
+}
+
+TEST(TEST_SUITE, ValHasCorrectDataType) {
+    bento::protos::Value val;
+    val.mutable_primitive()->set_int_64(3);
+
+    // No data type
+    ASSERT_FALSE(valHasCorrectDataType(val));
+
+    // Mismatched
+    val.mutable_data_type()->set_primitive(bento::protos::Type_Primitive_BOOL);
+    ASSERT_FALSE(valHasCorrectDataType(val));
+
+    // Correct data type
+    val.mutable_data_type()->set_primitive(bento::protos::Type_Primitive_INT64);
+    ASSERT_TRUE(valHasCorrectDataType(val));
 }


### PR DESCRIPTION
Fixes #54, #55 

To allow `mutateOp` to implicitly convert types, the `userComponent::setValue` function has been updated. It checks if the value is numeric before trying to cast between numeric types.

New functions have also been added to handle `bento::protos::Type` values.